### PR TITLE
Properly handling async model for initializing MediaCapture

### DIFF
--- a/patches_for_WebRTC_org/m80/0007.2-Properly-handling-async-model-for-initializing-Media.patch
+++ b/patches_for_WebRTC_org/m80/0007.2-Properly-handling-async-model-for-initializing-Media.patch
@@ -1,19 +1,34 @@
-From ee2a99a20bd6d53f0314a0303cff730391494ff9 Mon Sep 17 00:00:00 2001
+From c48576f03202179141476832cba6a76b4f4eddd7 Mon Sep 17 00:00:00 2001
 From: Augusto Righetto <aurighet@microsoft.com>
 Date: Wed, 27 May 2020 23:38:26 -0700
 Subject: [PATCH] Properly handling async model for initializing MediaCapture
  object
 
 Working around the stride and gap issues with NV12 memory layout
+
+Replacing error handling pattern from "Jump On Fail" to "Cascading ifs"
+    Removing THR and its goto
+
+Removing use of the ReleaseInterface function
+
+help_functions_winrt.cc without the sinful goto
+
+video_capture_winrt.cc deprived of all goto sins
+
+device_info_winrt, repent for the goto sins
+
+No more goto or THR sins
+
+Not using ReleaseInterface anymore
 ---
- .../windows/device_info_winrt.cc              | 178 ++++++----------
- .../windows/help_functions_winrt.cc           | 199 +++++++++++++++++-
- .../windows/help_functions_winrt.h            |  53 ++++-
- .../windows/video_capture_winrt.cc            |  61 ++++--
- 4 files changed, 342 insertions(+), 149 deletions(-)
+ .../windows/device_info_winrt.cc              | 402 +++++++------
+ .../windows/help_functions_winrt.cc           | 335 +++++++++--
+ .../windows/help_functions_winrt.h            | 123 ++--
+ .../windows/video_capture_winrt.cc            | 565 ++++++++++++------
+ 4 files changed, 937 insertions(+), 488 deletions(-)
 
 diff --git a/modules/video_capture/windows/device_info_winrt.cc b/modules/video_capture/windows/device_info_winrt.cc
-index 3b2a7aa773..2a7676be1a 100644
+index 3b2a7aa773..3e21c292cc 100644
 --- a/modules/video_capture/windows/device_info_winrt.cc
 +++ b/modules/video_capture/windows/device_info_winrt.cc
 @@ -26,34 +26,49 @@
@@ -103,7 +118,7 @@ index 3b2a7aa773..2a7676be1a 100644
    HRESULT GetNumberOfDevices(uint32_t* device_count);
  
    HRESULT GetDeviceName(uint32_t device_number,
-@@ -85,71 +98,31 @@ struct DeviceInfoWinRTInternal {
+@@ -85,95 +98,62 @@ struct DeviceInfoWinRTInternal {
        vector<VideoCaptureCapability>* video_capture_capabilities);
  
   private:
@@ -119,17 +134,29 @@ index 3b2a7aa773..2a7676be1a 100644
  };
  
 -HRESULT DeviceInfoWinRTInternal::AssureDeviceInformation() {
--  HRESULT hr = S_OK;
--
++DeviceInfoWinRTInternal::DeviceInfoWinRTInternal() {}
++
++HRESULT DeviceInfoWinRTInternal::GetDeviceInformationCollection(
++    IVectorView<DeviceInformation*>** device_collection) {
+   HRESULT hr = S_OK;
++  ComPtr<IActivationFactory> activation_factory;
++  ComPtr<IDeviceInformationStatics> device_info_statics;
++  ComPtr<IAsyncOperation<DeviceInformationCollection*>>
++      async_op_device_info_collection;
+ 
 -  if (!device_info_statics_) {
 -    // Get the object containing the DeviceInformation static methods.
 -    THR(GetActivationFactory(
--        HStringReference(
--            RuntimeClass_Windows_Devices_Enumeration_DeviceInformation)
--            .Get(),
++  // Get the object containing the DeviceInformation static methods.
++  if (SUCCEEDED(hr)) {
++    hr = GetActivationFactory(
+         HStringReference(
+             RuntimeClass_Windows_Devices_Enumeration_DeviceInformation)
+             .Get(),
 -        &device_info_statics_));
--  }
--
++        &activation_factory);
+   }
+ 
 -Cleanup:
 -  return hr;
 -}
@@ -163,42 +190,66 @@ index 3b2a7aa773..2a7676be1a 100644
 -Cleanup:
 -  return hr;
 -}
-+DeviceInfoWinRTInternal::DeviceInfoWinRTInternal() {}
+-
+-HRESULT DeviceInfoWinRTInternal::GetDeviceInformationCollection(
+-    IVectorView<DeviceInformation*>** device_collection) {
+-  HRESULT hr;
+-  ComPtr<IAsyncOperation<DeviceInformationCollection*>>
+-      async_op_device_info_collection;
++  if (SUCCEEDED(hr)) {
++    hr = activation_factory.As<IDeviceInformationStatics>(&device_info_statics);
++  }
  
- HRESULT DeviceInfoWinRTInternal::GetDeviceInformationCollection(
-     IVectorView<DeviceInformation*>** device_collection) {
-   HRESULT hr;
-+  ComPtr<IActivationFactory> activation_factory;
-+  ComPtr<IDeviceInformationStatics> device_info_statics;
-   ComPtr<IAsyncOperation<DeviceInformationCollection*>>
-       async_op_device_info_collection;
- 
-+  // Get the object containing the DeviceInformation static methods.
-+  THR(GetActivationFactory(
-+      HStringReference(
-+          RuntimeClass_Windows_Devices_Enumeration_DeviceInformation)
-+          .Get(),
-+      &activation_factory));
-+
-+  THR(activation_factory.As<IDeviceInformationStatics>(&device_info_statics));
-+
    // Call FindAllAsync and then start the async operation.
 -  THR(device_info_statics_->FindAllAsyncDeviceClass(
-+  THR(device_info_statics->FindAllAsyncDeviceClass(
-       DeviceClass_VideoCapture, &async_op_device_info_collection));
+-      DeviceClass_VideoCapture, &async_op_device_info_collection));
++  if (SUCCEEDED(hr)) {
++    hr = device_info_statics->FindAllAsyncDeviceClass(
++        DeviceClass_VideoCapture, &async_op_device_info_collection);
++  }
  
    // Block and suspend thread until the async operation finishes or timeouts.
-@@ -166,9 +139,6 @@ HRESULT DeviceInfoWinRTInternal::GetNumberOfDevices(uint32_t* device_count) {
-   HRESULT hr;
+-  THR(WaitForAsyncOperation(async_op_device_info_collection));
++  if (SUCCEEDED(hr)) {
++    hr = WaitForAsyncOperation(async_op_device_info_collection);
++  }
+ 
+   // Returns device collection if async operation completed successfully.
+-  THR(async_op_device_info_collection->GetResults(device_collection));
++  if (SUCCEEDED(hr)) {
++    hr = async_op_device_info_collection->GetResults(device_collection);
++  }
+ 
+-Cleanup:
+   return hr;
+ }
+ 
+ HRESULT DeviceInfoWinRTInternal::GetNumberOfDevices(uint32_t* device_count) {
+-  HRESULT hr;
    ComPtr<IVectorView<DeviceInformation*>> device_info_collection;
  
 -  // Assures class has been properly initialized.
 -  THR(AssureInitialized());
--
-   THR(GetDeviceInformationCollection(
-       device_info_collection.ReleaseAndGetAddressOf()));
-   THR(device_info_collection->get_Size(device_count));
-@@ -190,9 +160,6 @@ HRESULT DeviceInfoWinRTInternal::GetDeviceName(
++  HRESULT hr = GetDeviceInformationCollection(
++      device_info_collection.ReleaseAndGetAddressOf());
+ 
+-  THR(GetDeviceInformationCollection(
+-      device_info_collection.ReleaseAndGetAddressOf()));
+-  THR(device_info_collection->get_Size(device_count));
++  if (SUCCEEDED(hr)) {
++    hr = device_info_collection->get_Size(device_count);
++  }
+ 
+-Cleanup:
+   return hr;
+ }
+ 
+@@ -185,183 +165,215 @@ HRESULT DeviceInfoWinRTInternal::GetDeviceName(
+     uint32_t device_unique_id_UTF8_length,
+     char* product_unique_id_UTF8,
+     uint32_t product_unique_id_UTF8_length) {
+-  HRESULT hr;
+   uint32_t device_count;
    ComPtr<IVectorView<DeviceInformation*>> device_info_collection;
    ComPtr<IDeviceInformation> device_info;
  
@@ -206,15 +257,152 @@ index 3b2a7aa773..2a7676be1a 100644
 -  THR(AssureInitialized());
 -
    // Gets the device information collection synchronously
-   THR(GetDeviceInformationCollection(
-       device_info_collection.ReleaseAndGetAddressOf()));
-@@ -281,41 +248,26 @@ HRESULT DeviceInfoWinRTInternal::CreateCapabilityMap(
+-  THR(GetDeviceInformationCollection(
+-      device_info_collection.ReleaseAndGetAddressOf()));
++  HRESULT hr = GetDeviceInformationCollection(
++      device_info_collection.ReleaseAndGetAddressOf());
+ 
+   // Checks if desired device index is within the collection
+-  THR(device_info_collection->get_Size(&device_count));
+-  if (device_number >= device_count) {
++  if (SUCCEEDED(hr)) {
++    hr = device_info_collection->get_Size(&device_count);
++  }
++
++  if (SUCCEEDED(hr) && (device_number >= device_count)) {
+     RTC_LOG(LS_INFO) << "Device number is out of bounds";
+-    THR(E_BOUNDS);
++    hr = E_BOUNDS;
+   }
+ 
+-  THR(device_info_collection->GetAt(device_number, &device_info));
++  if (SUCCEEDED(hr)) {
++    hr = device_info_collection->GetAt(device_number, &device_info);
++  }
+ 
+-  if (device_name_length > 0) {
++  if (SUCCEEDED(hr) && (device_name_length > 0)) {
+     HString video_capture_name;
+-    THR(device_info->get_Name(video_capture_name.ReleaseAndGetAddressOf()));
++    hr = device_info->get_Name(video_capture_name.ReleaseAndGetAddressOf());
+ 
+     // rtc::ToUtf8 does not check for errors
+-    if (::WideCharToMultiByte(CP_UTF8, 0,
++    if (SUCCEEDED(hr) &&
++        ::WideCharToMultiByte(CP_UTF8, 0,
+                               video_capture_name.GetRawBuffer(nullptr), -1,
+                               reinterpret_cast<char*>(device_name_UTF8),
+                               device_name_length, NULL, NULL) == 0) {
+       RTC_LOG(LS_INFO) << "Failed to convert device name to UTF8, error = "
+                        << GetLastError();
+-      THR(E_FAIL);
++      hr = E_FAIL;
+     }
+   }
+ 
+-  if (device_unique_id_UTF8_length > 0) {
++  if (SUCCEEDED(hr) && (device_unique_id_UTF8_length > 0)) {
+     HString video_capture_id;
+-    THR(device_info->get_Id(video_capture_id.ReleaseAndGetAddressOf()));
++    hr = device_info->get_Id(video_capture_id.ReleaseAndGetAddressOf());
+ 
+     // rtc::ToUtf8 does not check for errors
+-    if (::WideCharToMultiByte(CP_UTF8, 0,
+-                              video_capture_id.GetRawBuffer(nullptr), -1,
+-                              reinterpret_cast<char*>(device_unique_id_UTF8),
+-                              device_unique_id_UTF8_length, NULL, NULL) == 0) {
++    if (SUCCEEDED(hr) && ::WideCharToMultiByte(
++                             CP_UTF8, 0, video_capture_id.GetRawBuffer(nullptr),
++                             -1, reinterpret_cast<char*>(device_unique_id_UTF8),
++                             device_unique_id_UTF8_length, NULL, NULL) == 0) {
+       RTC_LOG(LS_INFO) << "Failed to convert device id to UTF8, error = "
+                        << GetLastError();
+-      THR(E_FAIL);
++      hr = E_FAIL;
+     }
+   }
+ 
+-  if (product_unique_id_UTF8_length > 0) {
++  if (SUCCEEDED(hr) && product_unique_id_UTF8_length > 0) {
+     HString video_capture_id_hs;
+     unsigned int hs_lenght;
+     const wchar_t* video_capture_id_wc;
+     std::unique_ptr<wchar_t[]> buffer;
+     wchar_t *token, *next_token;
+ 
+-    THR(device_info->get_Id(video_capture_id_hs.ReleaseAndGetAddressOf()));
+-    video_capture_id_wc = video_capture_id_hs.GetRawBuffer(&hs_lenght);
+-    THR(video_capture_id_wc ? S_OK : E_FAIL);
++    hr = device_info->get_Id(video_capture_id_hs.ReleaseAndGetAddressOf());
+ 
+-    // hs_lenght doesn't count \0 needed by wcscpy_s.
+-    ++hs_lenght;
++    if (SUCCEEDED(hr)) {
++      video_capture_id_wc = video_capture_id_hs.GetRawBuffer(&hs_lenght);
++      hr = video_capture_id_wc ? S_OK : E_FAIL;
++    }
+ 
+-    // The contents of the HString has to be copied to buffer because wcstok_s
+-    // is destructive operation.
+-    buffer = std::make_unique<wchar_t[]>(hs_lenght);
+-    THR(buffer ? S_OK : E_OUTOFMEMORY);
+-    THR(0 == wcscpy_s(buffer.get(), hs_lenght, video_capture_id_wc) ? S_OK
+-                                                                    : E_FAIL);
++    if (SUCCEEDED(hr)) {
++      // hs_lenght doesn't count \0 needed by wcscpy_s.
++      ++hs_lenght;
++
++      // The contents of the HString has to be copied to buffer because wcstok_s
++      // is destructive operation.
++      buffer = std::make_unique<wchar_t[]>(hs_lenght);
++      hr = buffer ? S_OK : E_OUTOFMEMORY;
++    }
++
++    if (SUCCEEDED(hr)) {
++      hr = (0 == wcscpy_s(buffer.get(), hs_lenght, video_capture_id_wc)
++                ? S_OK
++                : E_FAIL);
++    }
++
++    if (SUCCEEDED(hr)) {
++      token = wcstok_s(buffer.get(), L"&", &next_token);
++      hr = token ? S_OK : E_FAIL;
++    }
+ 
+-    token = wcstok_s(buffer.get(), L"&", &next_token);
+-    THR(token ? S_OK : E_FAIL);
+-    token = wcstok_s(nullptr, L"&", &next_token);
+-    THR(token ? S_OK : E_FAIL);
++    if (SUCCEEDED(hr)) {
++      token = wcstok_s(nullptr, L"&", &next_token);
++      hr = token ? S_OK : E_FAIL;
++    }
+ 
+     // rtc::ToUtf8 does not check for errors
+-    if (::WideCharToMultiByte(CP_UTF8, 0, token, -1,
++    if (SUCCEEDED(hr) &&
++        ::WideCharToMultiByte(CP_UTF8, 0, token, -1,
+                               reinterpret_cast<char*>(product_unique_id_UTF8),
+                               product_unique_id_UTF8_length, NULL, NULL) == 0) {
+       RTC_LOG(LS_INFO)
+           << "Failed to convert product unique id to UTF8, error = "
+           << GetLastError();
+-      THR(E_FAIL);
++      hr = E_FAIL;
+     }
+   }
+ 
+-Cleanup:
+   return hr;
+-}
++}  // namespace videocapturemodule
+ 
+ HRESULT DeviceInfoWinRTInternal::CreateCapabilityMap(
      const wchar_t* device_unique_id,
      vector<VideoCaptureCapability>* video_capture_capabilities) {
-   HRESULT hr;
+-  HRESULT hr;
 -  ComPtr<IMediaCaptureInitializationSettings> init_settings;
 -  ComPtr<IMediaCaptureInitializationSettings5> init_settings5;
-+
    ComPtr<IMediaCapture> media_capture;
    ComPtr<IClosable> media_capture_closable;
    ComPtr<IAsyncAction> async_action;
@@ -230,7 +418,8 @@ index 3b2a7aa773..2a7676be1a 100644
    unsigned int stream_capabilities_size;
    vector<VideoCaptureCapability> device_caps;
  
-   THR(video_capture_capabilities ? S_OK : E_INVALIDARG);
+-  THR(video_capture_capabilities ? S_OK : E_INVALIDARG);
++  HRESULT hr = video_capture_capabilities ? S_OK : E_INVALIDARG;
  
 -  // Assures class has been properly initialized.
 -  THR(AssureInitialized());
@@ -248,17 +437,120 @@ index 3b2a7aa773..2a7676be1a 100644
 -  THR(ActivateInstance(
 -      HStringReference(RuntimeClass_Windows_Media_Capture_MediaCapture).Get(),
 -      &media_capture));
--
++  if (SUCCEEDED(hr)) {
++    hr = GetMediaCaptureForDevice(device_id.Get(), media_capture);
++  }
+ 
 -  THR(media_capture->InitializeWithSettingsAsync(init_settings.Get(),
 -                                                 &async_action));
--
--  THR(WaitForAsyncAction(async_action));
-+  THR(GetMediaCaptureForDevice(device_id.Get(),
-+                               media_capture.ReleaseAndGetAddressOf()));
++  if (SUCCEEDED(hr)) {
++    hr = media_capture->get_VideoDeviceController(&video_device_controller);
++  }
  
-   THR(media_capture->get_VideoDeviceController(&video_device_controller));
-   THR(video_device_controller.As<IMediaDeviceController>(
-@@ -389,7 +341,7 @@ DeviceInfoWinRT::~DeviceInfoWinRT() {
+-  THR(WaitForAsyncAction(async_action));
++  if (SUCCEEDED(hr)) {
++    hr = video_device_controller.As<IMediaDeviceController>(
++        &media_device_controller);
++  }
+ 
+-  THR(media_capture->get_VideoDeviceController(&video_device_controller));
+-  THR(video_device_controller.As<IMediaDeviceController>(
+-      &media_device_controller));
++  if (SUCCEEDED(hr)) {
++    hr = media_device_controller->GetAvailableMediaStreamProperties(
++        MediaStreamType::MediaStreamType_VideoRecord, &stream_capabilities);
++  }
+ 
+-  THR(media_device_controller->GetAvailableMediaStreamProperties(
+-      MediaStreamType::MediaStreamType_VideoRecord, &stream_capabilities));
++  if (SUCCEEDED(hr)) {
++    hr = stream_capabilities->get_Size(&stream_capabilities_size);
++  }
+ 
+-  THR(stream_capabilities->get_Size(&stream_capabilities_size));
+-  for (unsigned int i = 0; i < stream_capabilities_size; ++i) {
++  for (unsigned int i = 0; SUCCEEDED(hr) && i < stream_capabilities_size; ++i) {
+     ComPtr<IMediaEncodingProperties> media_encoding_props;
+     ComPtr<IVideoEncodingProperties> video_encoding_props;
+     ComPtr<IMediaRatio> media_ratio;
+     VideoCaptureCapability video_capture_capability;
+     HString subtype;
+ 
+-    THR(stream_capabilities->GetAt(i, &media_encoding_props));
++    if (SUCCEEDED(hr)) {
++      hr = stream_capabilities->GetAt(i, &media_encoding_props);
++    }
++
++    if (SUCCEEDED(hr)) {
++      hr = media_encoding_props.As<IVideoEncodingProperties>(
++          &video_encoding_props);
++    }
++
++    if (SUCCEEDED(hr)) {
++      hr = video_encoding_props->get_Width(
++          reinterpret_cast<UINT32*>(&video_capture_capability.width));
++    }
++
++    if (SUCCEEDED(hr)) {
++      hr = video_encoding_props->get_Height(
++          reinterpret_cast<UINT32*>(&video_capture_capability.height));
++    }
+ 
+-    THR(media_encoding_props.As<IVideoEncodingProperties>(
+-        &video_encoding_props));
++    if (SUCCEEDED(hr)) {
++      hr = video_encoding_props->get_FrameRate(&media_ratio);
++    }
+ 
+-    THR(video_encoding_props->get_Width(
+-        reinterpret_cast<UINT32*>(&video_capture_capability.width)));
++    if (SUCCEEDED(hr)) {
++      video_capture_capability.maxFPS =
++          SafelyComputeMediaRatio(media_ratio.Get());
+ 
+-    THR(video_encoding_props->get_Height(
+-        reinterpret_cast<UINT32*>(&video_capture_capability.height)));
++      hr = media_encoding_props->get_Subtype(subtype.ReleaseAndGetAddressOf());
++    }
+ 
+-    THR(video_encoding_props->get_FrameRate(&media_ratio));
+-    video_capture_capability.maxFPS =
+-        SafelyComputeMediaRatio(media_ratio.Get());
++    if (SUCCEEDED(hr)) {
++      video_capture_capability.videoType = ToVideoType(subtype);
+ 
+-    THR(media_encoding_props->get_Subtype(subtype.ReleaseAndGetAddressOf()));
+-    video_capture_capability.videoType = ToVideoType(subtype);
++      video_capture_capability.interlaced = false;
+ 
+-    video_capture_capability.interlaced = false;
++      device_caps.push_back(video_capture_capability);
++    }
++  }
+ 
+-    device_caps.push_back(video_capture_capability);
++  if (SUCCEEDED(hr)) {
++    hr = media_capture.As<IClosable>(&media_capture_closable);
+   }
+ 
+-  THR(media_capture.As<IClosable>(&media_capture_closable));
+-  THR(media_capture_closable->Close());
++  if (SUCCEEDED(hr)) {
++    hr = media_capture_closable->Close();
++  }
+ 
+-  // All media calls succeeded, let's copy the results.
+-  video_capture_capabilities->swap(device_caps);
++  if (SUCCEEDED(hr)) {
++    // All media calls succeeded, let's copy the results.
++    video_capture_capabilities->swap(device_caps);
++  }
+ 
+-Cleanup:
+   return hr;
+ }
+ 
+@@ -389,18 +401,15 @@ DeviceInfoWinRT::~DeviceInfoWinRT() {
  }
  
  int32_t DeviceInfoWinRT::Init() {
@@ -267,11 +559,50 @@ index 3b2a7aa773..2a7676be1a 100644
  }
  
  uint32_t DeviceInfoWinRT::NumberOfDevices() {
+   ReadLockScoped cs(_apiLock);
+-
+-  HRESULT hr;
+   uint32_t device_count = -1;
+ 
+-  THR(Impl(device_info_internal_)->GetNumberOfDevices(&device_count));
++  HRESULT hr = Impl(device_info_internal_)->GetNumberOfDevices(&device_count);
+ 
+-Cleanup:
+   return SUCCEEDED(hr) ? device_count : -1;
+ }
+ 
+@@ -413,19 +422,16 @@ int32_t DeviceInfoWinRT::GetDeviceName(uint32_t device_number,
+                                        uint32_t product_unique_id_UTF8_length) {
+   ReadLockScoped cs(_apiLock);
+ 
+-  HRESULT hr;
+-
+-  THR(Impl(device_info_internal_)
+-          ->GetDeviceName(device_number, device_name_UTF8, device_name_length,
+-                          device_unique_id_UTF8, device_unique_id_UTF8_length,
+-                          product_unique_id_UTF8,
+-                          product_unique_id_UTF8_length));
++  HRESULT hr = Impl(device_info_internal_)
++                   ->GetDeviceName(
++                       device_number, device_name_UTF8, device_name_length,
++                       device_unique_id_UTF8, device_unique_id_UTF8_length,
++                       product_unique_id_UTF8, product_unique_id_UTF8_length);
+ 
+-  if (device_name_length) {
+-    RTC_LOG(LS_INFO) << __FUNCTION__ << " " << device_name_UTF8;
++  if (SUCCEEDED(hr) && device_name_length) {
++    RTC_LOG_F(LS_INFO) << " " << device_name_UTF8;
+   }
+ 
+-Cleanup:
+   return SUCCEEDED(hr) ? 0 : -1;
+ }
+ 
 diff --git a/modules/video_capture/windows/help_functions_winrt.cc b/modules/video_capture/windows/help_functions_winrt.cc
-index 709c685b26..83f599fb6f 100644
+index 709c685b26..285abca235 100644
 --- a/modules/video_capture/windows/help_functions_winrt.cc
 +++ b/modules/video_capture/windows/help_functions_winrt.cc
-@@ -10,19 +10,175 @@
+@@ -10,29 +10,231 @@
  
  #include "modules/video_capture/windows/help_functions_winrt.h"
  
@@ -323,173 +654,335 @@ index 709c685b26..83f599fb6f 100644
  namespace webrtc {
  namespace videocapturemodule {
  
-+HRESULT GetMediaCaptureForDevice(HSTRING device_id,
-+                                  IMediaCapture** ppMediaCapture) {
-+  HRESULT hr;
++HRESULT InitializeMediaCapture(const AgileRef& media_capture_agile,
++                               const HSTRING& device_id,
++                               ComPtr<IAsyncAction>& media_capture_async) {
++  ComPtr<IMediaCapture> media_capture;
++  ComPtr<IMediaCaptureInitializationSettings> init_settings;
++  ComPtr<IMediaCaptureInitializationSettings5> init_settings5;
 +
++  HRESULT hr = media_capture_agile.As(&media_capture);
++
++  // Creates the settings used to select which capture device will be
++  // used.
++  if (SUCCEEDED(hr)) {
++    hr = ActivateInstance(
++        HStringReference(
++            RuntimeClass_Windows_Media_Capture_MediaCaptureInitializationSettings)
++            .Get(),
++        &init_settings);
++  }
++
++  if (SUCCEEDED(hr)) {
++    hr = init_settings->put_StreamingCaptureMode(
++        StreamingCaptureMode::StreamingCaptureMode_Video);
++  }
++
++  if (SUCCEEDED(hr)) {
++    hr =
++        init_settings.As<IMediaCaptureInitializationSettings5>(&init_settings5);
++  }
++
++  if (SUCCEEDED(hr)) {
++    hr = init_settings5->put_MemoryPreference(
++        MediaCaptureMemoryPreference::MediaCaptureMemoryPreference_Cpu);
++  }
++
++  if (SUCCEEDED(hr)) {
++    hr = init_settings->put_VideoDeviceId(device_id);
++  }
++
++  if (SUCCEEDED(hr)) {
++    hr = media_capture->InitializeWithSettingsAsync(init_settings.Get(),
++                                                    &media_capture_async);
++  }
++
++  return hr;
++}
++
++HRESULT GetMediaCaptureForDevice(HSTRING device_id,
++                                 ComPtr<IMediaCapture>& media_capture) {
 +  ComPtr<ICoreDispatcher> main_view_dispatcher;
 +  ComPtr<IAsyncAction> async_action_ui_dispatcher;
 +  ComPtr<IAsyncAction> async_action_media_capture;
-+  ComPtr<IMediaCapture> media_capture;
-+  AgileRef media_capture_agile;
 +  AgileRef async_action_media_capture_agile;
++  AgileRef media_capture_agile;
 +  Event event_wait_for_media_capture_async_action;
 +  Event event_wait_for_media_capture_async_action_completion;
 +  boolean has_thread_access;
 +
 +  // Acquires the main view dispacther (UI thread).
-+  THR(GetMainViewDispatcher(&main_view_dispatcher));
++  HRESULT hr = GetMainViewDispatcher(&main_view_dispatcher);
 +
 +  // We'll be dispatching and waiting for code from the UI thread.
 +  // Let's make sure this is not the UI thread.
-+  THR(main_view_dispatcher->get_HasThreadAccess(&has_thread_access));
-+  THR(has_thread_access ? RPC_E_WRONG_THREAD : S_OK);
++  if (SUCCEEDED(hr)) {
++    hr = main_view_dispatcher->get_HasThreadAccess(&has_thread_access);
++  }
++
++  if (SUCCEEDED(hr)) {
++    hr = has_thread_access ? RPC_E_WRONG_THREAD : S_OK;
++  }
 +
 +  // The media capture device has to be initialized in the UI thread.
 +  // The following event is used for letting this thread know that
 +  // async_action_media_capture has been created.
-+  event_wait_for_media_capture_async_action =
-+      Event(::CreateEventEx(nullptr, nullptr, CREATE_EVENT_MANUAL_RESET,
-+                            WRITE_OWNER | EVENT_ALL_ACCESS));
-+  THR(event_wait_for_media_capture_async_action.IsValid()
-+          ? S_OK
-+          : HRESULT_FROM_WIN32(GetLastError()));
++  if (SUCCEEDED(hr)) {
++    event_wait_for_media_capture_async_action =
++        Event(::CreateEventEx(nullptr, nullptr, CREATE_EVENT_MANUAL_RESET,
++                              WRITE_OWNER | EVENT_ALL_ACCESS));
++  }
 +
-+  THR(ActivateInstance(
-+      HStringReference(RuntimeClass_Windows_Media_Capture_MediaCapture).Get(),
-+      media_capture.ReleaseAndGetAddressOf()));
++  if (SUCCEEDED(hr)) {
++    hr = event_wait_for_media_capture_async_action.IsValid()
++             ? S_OK
++             : HRESULT_FROM_WIN32(GetLastError());
++  }
 +
-+  THR(media_capture.AsAgile(&media_capture_agile));
++  if (SUCCEEDED(hr)) {
++    hr = ActivateInstance(
++        HStringReference(RuntimeClass_Windows_Media_Capture_MediaCapture).Get(),
++        media_capture.ReleaseAndGetAddressOf());
++  }
++
++  if (SUCCEEDED(hr)) {
++    hr = media_capture.AsAgile(&media_capture_agile);
++  }
 +
 +  // Dispatches the media capture initialization to the main view
 +  // dispatcher.
-+  THR(main_view_dispatcher->RunAsync(
-+      CoreDispatcherPriority::CoreDispatcherPriority_Normal,
-+      Callback<Implements<RuntimeClassFlags<Delegate>, IDispatchedHandler,
-+                          FtmBase>>([&event_wait_for_media_capture_async_action,
-+                                     &async_action_media_capture_agile,
-+                                     &media_capture_agile,
-+                                     &device_id]() -> HRESULT {
-+        HRESULT hr;
++  if (SUCCEEDED(hr)) {
++    hr = main_view_dispatcher->RunAsync(
++        CoreDispatcherPriority::CoreDispatcherPriority_Normal,
++        Callback<Implements<RuntimeClassFlags<Delegate>, IDispatchedHandler,
++                            FtmBase>>(
++            [&event_wait_for_media_capture_async_action,
++             &async_action_media_capture_agile, &media_capture_agile,
++             &device_id]() -> HRESULT {
++              ComPtr<IAsyncAction> media_capture_async;
++              HRESULT hr = InitializeMediaCapture(
++                  media_capture_agile, device_id, media_capture_async);
 +
-+        ComPtr<IMediaCapture> media_capture;
-+        ComPtr<IAsyncAction> media_capture_async;
-+        ComPtr<IMediaCaptureInitializationSettings> init_settings;
-+        ComPtr<IMediaCaptureInitializationSettings5> init_settings5;
++              if (SUCCEEDED(hr)) {
++                hr = media_capture_async.AsAgile(
++                    &async_action_media_capture_agile);
++              }
 +
-+        THR(media_capture_agile.As(&media_capture));
++              ::SetEvent(event_wait_for_media_capture_async_action.Get());
 +
-+        // Creates the settings used to select which capture device will be
-+        // used.
-+        THR(ActivateInstance(
-+            HStringReference(
-+                RuntimeClass_Windows_Media_Capture_MediaCaptureInitializationSettings)
-+                .Get(),
-+            &init_settings));
-+        THR(init_settings->put_StreamingCaptureMode(
-+            StreamingCaptureMode::StreamingCaptureMode_AudioAndVideo));
-+        THR(init_settings.As<IMediaCaptureInitializationSettings5>(
-+            &init_settings5));
-+        THR(init_settings5->put_MemoryPreference(
-+            MediaCaptureMemoryPreference::MediaCaptureMemoryPreference_Cpu));
-+        THR(init_settings->put_VideoDeviceId(device_id));
-+
-+        THR(media_capture->InitializeWithSettingsAsync(init_settings.Get(),
-+                                                       &media_capture_async));
-+
-+        THR(media_capture_async.AsAgile(&async_action_media_capture_agile));
-+
-+      Cleanup:
-+        ::SetEvent(event_wait_for_media_capture_async_action.Get());
-+        return hr;
-+      }).Get(),
-+      &async_action_ui_dispatcher));
++              return hr;
++            })
++            .Get(),
++        &async_action_ui_dispatcher);
++  }
 +
 +  // Waits for the UI thread to create async_action_media_capture.
-+  THR(::WaitForSingleObjectEx(event_wait_for_media_capture_async_action.Get(),
-+                              INFINITE, FALSE) == WAIT_OBJECT_0
-+          ? S_OK
-+          : E_FAIL);
++  if (SUCCEEDED(hr)) {
++    hr =
++        ::WaitForSingleObjectEx(event_wait_for_media_capture_async_action.Get(),
++                                INFINITE, FALSE) == WAIT_OBJECT_0
++            ? S_OK
++            : E_FAIL;
++  }
 +
 +  // Waits for user to approve (or not) access to the microphone and
 +  // camera.
-+  event_wait_for_media_capture_async_action_completion =
-+      Event(::CreateEventEx(nullptr, nullptr, CREATE_EVENT_MANUAL_RESET,
-+                            WRITE_OWNER | EVENT_ALL_ACCESS));
-+  THR(event_wait_for_media_capture_async_action_completion.IsValid()
-+          ? S_OK
-+          : HRESULT_FROM_WIN32(GetLastError()));
++  if (SUCCEEDED(hr)) {
++    event_wait_for_media_capture_async_action_completion =
++        Event(::CreateEventEx(nullptr, nullptr, CREATE_EVENT_MANUAL_RESET,
++                              WRITE_OWNER | EVENT_ALL_ACCESS));
++    hr = event_wait_for_media_capture_async_action_completion.IsValid()
++             ? S_OK
++             : HRESULT_FROM_WIN32(GetLastError());
++  }
 +
 +  // Waits until user grant (or deny) access to the camera.
-+  THR(async_action_media_capture_agile.As(&async_action_media_capture));
-+  THR(async_action_media_capture->put_Completed(
-+      Callback<IAsyncActionCompletedHandler>(
-+          [&event_wait_for_media_capture_async_action_completion](
-+              IAsyncAction*, AsyncStatus async_status) -> HRESULT {
-+            HRESULT hr;
++  if (SUCCEEDED(hr)) {
++    hr = async_action_media_capture_agile.As(&async_action_media_capture);
++  }
 +
-+            // Checks if user granted permission to access the camera.
-+            THR(async_status == AsyncStatus::Completed ? S_OK : E_ACCESSDENIED);
++  if (SUCCEEDED(hr)) {
++    hr = async_action_media_capture->put_Completed(
++        Callback<IAsyncActionCompletedHandler>(
++            [&event_wait_for_media_capture_async_action_completion](
++                IAsyncAction*, AsyncStatus async_status) -> HRESULT {
++              ::SetEvent(
++                  event_wait_for_media_capture_async_action_completion.Get());
 +
-+          Cleanup:
-+            ::SetEvent(
-+                event_wait_for_media_capture_async_action_completion.Get());
++              // Checks if user granted permission to access the camera.
++              return async_status == AsyncStatus::Completed ? S_OK
++                                                            : E_ACCESSDENIED;
++            })
++            .Get());
++  }
 +
-+            return hr;
-+          })
-+          .Get()));
++  if (SUCCEEDED(hr)) {
++    hr = ::WaitForSingleObjectEx(
++             event_wait_for_media_capture_async_action_completion.Get(),
++             INFINITE, FALSE) == WAIT_OBJECT_0
++             ? S_OK
++             : E_FAIL;
++  }
 +
-+  THR(::WaitForSingleObjectEx(
-+          event_wait_for_media_capture_async_action_completion.Get(), INFINITE,
-+          FALSE) == WAIT_OBJECT_0
-+          ? S_OK
-+          : E_FAIL);
-+
-+  // User granted access, good to go.
-+  ReleaseInterface(ppMediaCapture);
-+  *ppMediaCapture = media_capture.Detach();
-+
-+Cleanup:
 +  return hr;
 +}
 +
  uint32_t SafelyComputeMediaRatio(IMediaRatio* ratio_no_ref) {
-   HRESULT hr;
+-  HRESULT hr;
    uint32_t numerator, denominator, media_ratio = 0;
-@@ -70,6 +226,31 @@ VideoType ToVideoType(const HString& sub_type) {
+ 
+-  THR(ratio_no_ref->get_Numerator(&numerator));
+-  THR(ratio_no_ref->get_Denominator(&denominator));
++  HRESULT hr = ratio_no_ref->get_Numerator(&numerator);
+ 
+-  media_ratio = (denominator != 0) ? numerator / denominator : 0;
++  if (SUCCEEDED(hr)) {
++    hr = ratio_no_ref->get_Denominator(&denominator);
++  }
++
++  if (SUCCEEDED(hr)) {
++    media_ratio = (denominator != 0) ? numerator / denominator : 0;
++  }
+ 
+-Cleanup:
+   return media_ratio;
+ }
+ 
+@@ -70,56 +272,103 @@ VideoType ToVideoType(const HString& sub_type) {
    return converted_type;
  }
  
 +HRESULT GetMainViewDispatcher(ICoreDispatcher** main_view_dispatcher) {
-+  HRESULT hr;
-+
 +  ComPtr<IActivationFactory> activation_factory;
 +  ComPtr<ICoreApplication> coreApplication;
 +  ComPtr<ICoreImmersiveApplication> immersiveApplication;
 +  ComPtr<ICoreApplicationView> applicationView;
 +  ComPtr<ICoreWindow> coreWindow;
 +
-+  THR(GetActivationFactory(
++  HRESULT hr = GetActivationFactory(
 +      HStringReference(
 +          RuntimeClass_Windows_ApplicationModel_Core_CoreApplication)
 +          .Get(),
-+      &activation_factory));
++      &activation_factory);
 +
-+  THR(activation_factory.As<ICoreApplication>(&coreApplication));
-+  THR(coreApplication.As<ICoreImmersiveApplication>(&immersiveApplication));
-+  THR(immersiveApplication->get_MainView(&applicationView));
-+  THR(applicationView->get_CoreWindow(&coreWindow));
-+  THR(coreWindow->get_Dispatcher(main_view_dispatcher));
++  if (SUCCEEDED(hr)) {
++    hr = activation_factory.As<ICoreApplication>(&coreApplication);
++  }
 +
-+Cleanup:
++  if (SUCCEEDED(hr)) {
++    hr = coreApplication.As<ICoreImmersiveApplication>(&immersiveApplication);
++  }
++
++  if (SUCCEEDED(hr)) {
++    hr = immersiveApplication->get_MainView(&applicationView);
++  }
++
++  if (SUCCEEDED(hr)) {
++    hr = applicationView->get_CoreWindow(&coreWindow);
++  }
++
++  if (SUCCEEDED(hr)) {
++    hr = coreWindow->get_Dispatcher(main_view_dispatcher);
++  }
++
 +  return hr;
 +}
 +
  HRESULT WaitForAsyncAction(ComPtr<IAsyncAction> async_action) {
-   HRESULT hr, hr_async_error;
-   const DWORD timeout_ms = 2000;
+-  HRESULT hr, hr_async_error;
+-  const DWORD timeout_ms = 2000;
++  HRESULT hr = S_OK;
++  HRESULT hr_async_error = S_OK;
+   ComPtr<IAsyncInfo> async_info;
+   Event event_completed;
++  const DWORD timeout_ms = 2000;
+ 
+ #if _DEBUG
+   APTTYPE apt_type;
+   APTTYPEQUALIFIER apt_qualifier;
+-  THR(CoGetApartmentType(&apt_type, &apt_qualifier));
++  hr = CoGetApartmentType(&apt_type, &apt_qualifier);
+   // Please make the caller of this API run on a MTA appartment type.
+   // The caller shouldn't be running on the UI thread (STA).
+-  assert(apt_type == APTTYPE_MTA);
++  if (SUCCEEDED(hr)) {
++    assert(apt_type == APTTYPE_MTA);
++  }
+ #endif  // _DEBUG
+ 
+   // Creates the Event to be used to block and suspend until the async
+   // operation finishes.
+-  event_completed =
+-      Event(CreateEventEx(nullptr, nullptr, CREATE_EVENT_MANUAL_RESET,
+-                          WRITE_OWNER | EVENT_ALL_ACCESS));
+-  THR(event_completed.IsValid() ? S_OK : HRESULT_FROM_WIN32(GetLastError()));
++  if (SUCCEEDED(hr)) {
++    event_completed =
++        Event(::CreateEventEx(nullptr, nullptr, CREATE_EVENT_MANUAL_RESET,
++                              WRITE_OWNER | EVENT_ALL_ACCESS));
++    hr = event_completed.IsValid() ? S_OK : HRESULT_FROM_WIN32(GetLastError());
++  }
+ 
+   // Defines the callback that will signal the event to unblock and resume.
+-  THR(async_action->put_Completed(
+-      Callback<IAsyncActionCompletedHandler>([&event_completed](
+-                                                 IAsyncAction*,
+-                                                 AsyncStatus async_status)
+-                                                 -> HRESULT {
+-        HRESULT hr;
+-
+-        THR(async_status == AsyncStatus::Completed ? S_OK : E_ABORT);
+-
+-      Cleanup:
+-        ::SetEvent(event_completed.Get());
++  if (SUCCEEDED(hr)) {
++    hr = async_action->put_Completed(
++        Callback<IAsyncActionCompletedHandler>([&event_completed](
++                                                   IAsyncAction*,
++                                                   AsyncStatus async_status)
++                                                   -> HRESULT {
++          ::SetEvent(event_completed.Get());
+ 
+-        return hr;
+-      }).Get()));
++          return async_status == AsyncStatus::Completed ? S_OK : E_ABORT;
++        }).Get());
++  }
+ 
+   // Block and suspend thread until the async operation finishes or timeout.
+-  THR(::WaitForSingleObjectEx(event_completed.Get(), timeout_ms, FALSE) ==
+-              WAIT_OBJECT_0
+-          ? S_OK
+-          : E_FAIL);
++  if (SUCCEEDED(hr)) {
++    hr = ::WaitForSingleObjectEx(event_completed.Get(), timeout_ms, FALSE) ==
++                 WAIT_OBJECT_0
++             ? S_OK
++             : E_FAIL;
++  }
+ 
+   // Checks if async operation completed successfully.
+-  THR(async_action.As<IAsyncInfo>(&async_info));
+-  THR(async_info->get_ErrorCode(&hr_async_error));
+-  THR(hr_async_error);
++  if (SUCCEEDED(hr)) {
++    hr = async_action.As<IAsyncInfo>(&async_info);
++  }
++
++  if (SUCCEEDED(hr)) {
++    hr = async_info->get_ErrorCode(&hr_async_error);
++  }
++
++  if (SUCCEEDED(hr)) {
++    hr = hr_async_error;
++  }
+ 
+-Cleanup:
+   return hr;
+ }
+ 
 diff --git a/modules/video_capture/windows/help_functions_winrt.h b/modules/video_capture/windows/help_functions_winrt.h
-index 0216d9b0ce..7c55f87654 100644
+index 0216d9b0ce..9dae10bcf0 100644
 --- a/modules/video_capture/windows/help_functions_winrt.h
 +++ b/modules/video_capture/windows/help_functions_winrt.h
 @@ -13,6 +13,7 @@
@@ -500,63 +993,27 @@ index 0216d9b0ce..7c55f87654 100644
  #include <wrl/client.h>
  #include <wrl/event.h>
  #include <wrl/wrappers/corewrappers.h>
-@@ -20,15 +21,50 @@
+@@ -20,85 +21,99 @@
  #include <cassert>
  
  #include "modules/video_capture/video_capture_defines.h"
-+#include "rtc_base/logging.h"
- 
- // Evaluates an expression returning a HRESULT.
- // It jumps to a label named Cleanup on failure.
+-
+-// Evaluates an expression returning a HRESULT.
+-// It jumps to a label named Cleanup on failure.
 -#define THR(expr)   \
 -  do {              \
 -    hr = (expr);    \
 -    if (FAILED(hr)) \
 -      goto Cleanup; \
-+#ifdef _DEBUG
-+#define THR(expr)                                           \
-+  do {                                                      \
-+    hr = (expr);                                            \
-+    if (FAILED(hr)) {                                       \
-+      RTC_LOG_F(LS_ERROR) << "HR: " << hr;                  \
-+      __debugbreak();                                       \
-+      goto Cleanup;                                         \
-+    }                                                       \
-   } while (false)
-+#else
-+#define THR(expr)     \
-+  do {                \
-+    hr = (expr);      \
-+    if (FAILED(hr)) { \
-+      goto Cleanup;   \
-+    }                 \
-+  } while (false)
-+#endif
-+
-+template <typename T>
-+void ReleaseInterface(T** ppInterface) {
-+  if ((*ppInterface)) {
-+    (*ppInterface)->Release();
-+    (*ppInterface) = nullptr;
-+  }
-+}
-+
-+template <typename T, typename U>
-+void ReplaceInterface(T** ppInterface, U* pSource) {
-+  if ((*ppInterface)) {
-+    (*ppInterface)->Release();
-+  }
-+
-+  (*ppInterface) = pSource;
-+
-+  if (pSource) {
-+    pSource->AddRef();
-+  }
-+}
+-  } while (false)
++#include "rtc_base/logging.h"
  
  namespace webrtc {
  namespace videocapturemodule {
-@@ -38,6 +74,13 @@ uint32_t SafelyComputeMediaRatio(
+ 
+ uint32_t SafelyComputeMediaRatio(
+-    ABI::Windows::Media::MediaProperties::IMediaRatio* ratio_no_ref);
++    ::ABI::Windows::Media::MediaProperties::IMediaRatio* ratio_no_ref);
  
  VideoType ToVideoType(const Microsoft::WRL::Wrappers::HString& sub_type);
  
@@ -565,37 +1022,287 @@ index 0216d9b0ce..7c55f87654 100644
 +
 +HRESULT GetMediaCaptureForDevice(
 +    HSTRING device_id,
-+    ::ABI::Windows::Media::Capture::IMediaCapture** pp_media_capture);
++    ::Microsoft::WRL::ComPtr<::ABI::Windows::Media::Capture::IMediaCapture>&
++        media_capture);
 +
  HRESULT WaitForAsyncAction(
-     Microsoft::WRL::ComPtr<ABI::Windows::Foundation::IAsyncAction>
+-    Microsoft::WRL::ComPtr<ABI::Windows::Foundation::IAsyncAction>
++    ::Microsoft::WRL::ComPtr<ABI::Windows::Foundation::IAsyncAction>
          async_action);
+ 
+ template <typename T>
+ HRESULT WaitForAsyncOperation(
+-    Microsoft::WRL::ComPtr<ABI::Windows::Foundation::IAsyncOperation<T>>&
++    ::Microsoft::WRL::ComPtr<ABI::Windows::Foundation::IAsyncOperation<T>>&
+         async_op) {
+-  HRESULT hr, hr_async_error;
++  using ::ABI::Windows::Foundation::AsyncStatus;
++  using ::ABI::Windows::Foundation::IAsyncInfo;
++  using ::ABI::Windows::Foundation::IAsyncOperation;
++  using ::ABI::Windows::Foundation::IAsyncOperationCompletedHandler;
++  using ::Microsoft::WRL::Callback;
++  using ::Microsoft::WRL::Wrappers::Event;
++
++  HRESULT hr = S_OK;
++  HRESULT hr_async_error = S_OK;
+   const DWORD timeout_ms = 2000;
+-  Microsoft::WRL::ComPtr<ABI::Windows::Foundation::IAsyncInfo> async_info;
+-  Microsoft::WRL::Wrappers::Event event_completed;
++  ComPtr<IAsyncInfo> async_info;
++  Event event_completed;
+ 
+ #if _DEBUG
+   APTTYPE apt_type;
+   APTTYPEQUALIFIER apt_qualifier;
+-  THR(CoGetApartmentType(&apt_type, &apt_qualifier));
++  hr = CoGetApartmentType(&apt_type, &apt_qualifier);
+   // Please make the caller of this API run on a MTA appartment type.
+   // The caller shouldn't be running on the UI thread (STA).
+-  assert(apt_type == APTTYPE_MTA);
++  if (SUCCEEDED(hr)) {
++    assert(apt_type == APTTYPE_MTA);
++  }
+ #endif  // _DEBUG
+ 
+   // Creates the Event to be used to block and suspend until the async
+   // operation finishes.
+-  event_completed = Microsoft::WRL::Wrappers::Event(
+-      ::CreateEventEx(nullptr, nullptr, CREATE_EVENT_MANUAL_RESET,
+-                      WRITE_OWNER | EVENT_ALL_ACCESS));
+-  THR(event_completed.IsValid() ? S_OK : E_HANDLE);
+-
+-  // Defines the callback that will signal the event to unblock and resume.
+-  THR(async_op->put_Completed(
+-      Microsoft::WRL::Callback<
+-          ABI::Windows::Foundation::IAsyncOperationCompletedHandler<T>>(
+-          [&event_completed](
+-              ABI::Windows::Foundation::IAsyncOperation<T>*,
+-              ABI::Windows::Foundation::AsyncStatus async_status) -> HRESULT {
+-            HRESULT hr;
+-
+-            THR(async_status == ABI::Windows::Foundation::AsyncStatus::Completed
+-                    ? S_OK
+-                    : E_ABORT);
+-
+-          Cleanup:
+-            ::SetEvent(event_completed.Get());
+-
+-            return hr;
+-          })
+-          .Get()));
+-
+-  // Block and suspend thread until the async operation finishes or timeout.
+-  THR(::WaitForSingleObjectEx(event_completed.Get(), timeout_ms, FALSE) ==
+-              WAIT_OBJECT_0
+-          ? S_OK
+-          : E_FAIL);
+-
+-  // Checks if async operation completed successfully.
+-  THR(async_op.template As<ABI::Windows::Foundation::IAsyncInfo>(&async_info));
+-  THR(async_info->get_ErrorCode(&hr_async_error));
+-  THR(hr_async_error);
+-
+-Cleanup:
++  event_completed =
++      Event(::CreateEventEx(nullptr, nullptr, CREATE_EVENT_MANUAL_RESET,
++                            WRITE_OWNER | EVENT_ALL_ACCESS));
++  if (SUCCEEDED(hr)) {
++    hr = event_completed.IsValid() ? S_OK : E_HANDLE;
++  }
++
++  if (SUCCEEDED(hr)) {
++    // Defines the callback that will signal the event to unblock and resume.
++    hr = async_op->put_Completed(
++        Callback<IAsyncOperationCompletedHandler<T>>(
++            [&event_completed](IAsyncOperation<T>*,
++                               AsyncStatus async_status) -> HRESULT {
++              ::SetEvent(event_completed.Get());
++
++              return async_status == Completed ? S_OK : E_ABORT;
++            })
++            .Get());
++  }
++
++  if (SUCCEEDED(hr)) {
++    // Block and suspend thread until the async operation finishes or timeout.
++    hr = ::WaitForSingleObjectEx(event_completed.Get(), timeout_ms, FALSE) ==
++                 WAIT_OBJECT_0
++             ? S_OK
++             : E_FAIL;
++  }
++
++  if (SUCCEEDED(hr)) {
++    // Checks if async operation completed successfully.
++    hr = async_op.template As<IAsyncInfo>(&async_info);
++  }
++
++  if (SUCCEEDED(hr)) {
++    hr = async_info->get_ErrorCode(&hr_async_error);
++  }
++
++  if (SUCCEEDED(hr)) {
++    hr = hr_async_error;
++  }
++
+   return hr;
+ }
+ 
 diff --git a/modules/video_capture/windows/video_capture_winrt.cc b/modules/video_capture/windows/video_capture_winrt.cc
-index 5aa3541b34..44d7cdca68 100644
+index 5aa3541b34..9a8c58c74f 100644
 --- a/modules/video_capture/windows/video_capture_winrt.cc
 +++ b/modules/video_capture/windows/video_capture_winrt.cc
-@@ -68,6 +68,7 @@ using ABI::Windows::Media::Capture::Frames::MediaFrameReaderStartStatus;
- using ABI::Windows::Media::Capture::Frames::MediaFrameSource;
- using ABI::Windows::Media::Capture::Frames::MediaFrameSourceKind;
- using ABI::Windows::Media::MediaProperties::IMediaRatio;
-+using ABI::Windows::Graphics::Imaging::BitmapPlaneDescription;
- using Microsoft::WRL::Callback;
- using Microsoft::WRL::ComPtr;
- using Microsoft::WRL::Wrappers::HString;
-@@ -141,9 +142,6 @@ Cleanup:
+@@ -32,46 +32,48 @@ struct __declspec(uuid("5b0d3235-4dba-4d44-865e-8f1d0e4fd04d")) __declspec(
+   virtual HRESULT __stdcall GetBuffer(uint8_t** value, uint32_t* capacity) = 0;
+ };
+ 
+-using ABI::Windows::Foundation::ActivateInstance;
+-using ABI::Windows::Foundation::IAsyncAction;
+-using ABI::Windows::Foundation::IAsyncOperation;
+-using ABI::Windows::Foundation::IClosable;
+-using ABI::Windows::Foundation::IMemoryBuffer;
+-using ABI::Windows::Foundation::IMemoryBufferReference;
+-using ABI::Windows::Foundation::ITypedEventHandler;
+-using ABI::Windows::Foundation::Collections::IIterable;
+-using ABI::Windows::Foundation::Collections::IIterator;
+-using ABI::Windows::Foundation::Collections::IKeyValuePair;
+-using ABI::Windows::Foundation::Collections::IMapView;
+-using ABI::Windows::Foundation::Collections::IVectorView;
+-using ABI::Windows::Graphics::Imaging::BitmapBufferAccessMode;
+-using ABI::Windows::Graphics::Imaging::IBitmapBuffer;
+-using ABI::Windows::Graphics::Imaging::ISoftwareBitmap;
+-using ABI::Windows::Media::Capture::IMediaCapture5;
+-using ABI::Windows::Media::Capture::IMediaCaptureInitializationSettings;
+-using ABI::Windows::Media::Capture::IMediaCaptureInitializationSettings5;
+-using ABI::Windows::Media::Capture::MediaCaptureMemoryPreference;
+-using ABI::Windows::Media::Capture::MediaStreamType;
+-using ABI::Windows::Media::Capture::StreamingCaptureMode;
+-using ABI::Windows::Media::Capture::Frames::IMediaFrameArrivedEventArgs;
+-using ABI::Windows::Media::Capture::Frames::IMediaFrameFormat;
+-using ABI::Windows::Media::Capture::Frames::IMediaFrameReader;
+-using ABI::Windows::Media::Capture::Frames::IMediaFrameReference;
+-using ABI::Windows::Media::Capture::Frames::IMediaFrameSource;
+-using ABI::Windows::Media::Capture::Frames::IMediaFrameSourceInfo;
+-using ABI::Windows::Media::Capture::Frames::IVideoMediaFrame;
+-using ABI::Windows::Media::Capture::Frames::IVideoMediaFrameFormat;
+-using ABI::Windows::Media::Capture::Frames::MediaFrameArrivedEventArgs;
+-using ABI::Windows::Media::Capture::Frames::MediaFrameFormat;
+-using ABI::Windows::Media::Capture::Frames::MediaFrameReader;
+-using ABI::Windows::Media::Capture::Frames::MediaFrameReaderStartStatus;
+-using ABI::Windows::Media::Capture::Frames::MediaFrameSource;
+-using ABI::Windows::Media::Capture::Frames::MediaFrameSourceKind;
+-using ABI::Windows::Media::MediaProperties::IMediaRatio;
+-using Microsoft::WRL::Callback;
+-using Microsoft::WRL::ComPtr;
+-using Microsoft::WRL::Wrappers::HString;
+-using Microsoft::WRL::Wrappers::HStringReference;
++using ::ABI::Windows::Foundation::ActivateInstance;
++using ::ABI::Windows::Foundation::IAsyncAction;
++using ::ABI::Windows::Foundation::IAsyncOperation;
++using ::ABI::Windows::Foundation::IClosable;
++using ::ABI::Windows::Foundation::IMemoryBuffer;
++using ::ABI::Windows::Foundation::IMemoryBufferReference;
++using ::ABI::Windows::Foundation::ITypedEventHandler;
++using ::ABI::Windows::Foundation::Collections::IIterable;
++using ::ABI::Windows::Foundation::Collections::IIterator;
++using ::ABI::Windows::Foundation::Collections::IKeyValuePair;
++using ::ABI::Windows::Foundation::Collections::IMapView;
++using ::ABI::Windows::Foundation::Collections::IVectorView;
++using ::ABI::Windows::Graphics::Imaging::BitmapBufferAccessMode;
++using ::ABI::Windows::Graphics::Imaging::BitmapPlaneDescription;
++using ::ABI::Windows::Graphics::Imaging::IBitmapBuffer;
++using ::ABI::Windows::Graphics::Imaging::ISoftwareBitmap;
++using ::ABI::Windows::Media::Capture::IMediaCapture;
++using ::ABI::Windows::Media::Capture::IMediaCapture5;
++using ::ABI::Windows::Media::Capture::IMediaCaptureInitializationSettings;
++using ::ABI::Windows::Media::Capture::IMediaCaptureInitializationSettings5;
++using ::ABI::Windows::Media::Capture::MediaCaptureMemoryPreference;
++using ::ABI::Windows::Media::Capture::MediaStreamType;
++using ::ABI::Windows::Media::Capture::StreamingCaptureMode;
++using ::ABI::Windows::Media::Capture::Frames::IMediaFrameArrivedEventArgs;
++using ::ABI::Windows::Media::Capture::Frames::IMediaFrameFormat;
++using ::ABI::Windows::Media::Capture::Frames::IMediaFrameReader;
++using ::ABI::Windows::Media::Capture::Frames::IMediaFrameReference;
++using ::ABI::Windows::Media::Capture::Frames::IMediaFrameSource;
++using ::ABI::Windows::Media::Capture::Frames::IMediaFrameSourceInfo;
++using ::ABI::Windows::Media::Capture::Frames::IVideoMediaFrame;
++using ::ABI::Windows::Media::Capture::Frames::IVideoMediaFrameFormat;
++using ::ABI::Windows::Media::Capture::Frames::MediaFrameArrivedEventArgs;
++using ::ABI::Windows::Media::Capture::Frames::MediaFrameFormat;
++using ::ABI::Windows::Media::Capture::Frames::MediaFrameReader;
++using ::ABI::Windows::Media::Capture::Frames::MediaFrameReaderStartStatus;
++using ::ABI::Windows::Media::Capture::Frames::MediaFrameSource;
++using ::ABI::Windows::Media::Capture::Frames::MediaFrameSourceKind;
++using ::ABI::Windows::Media::MediaProperties::IMediaRatio;
++using ::Microsoft::WRL::Callback;
++using ::Microsoft::WRL::ComPtr;
++using ::Microsoft::WRL::Wrappers::HString;
++using ::Microsoft::WRL::Wrappers::HStringReference;
+ 
+ namespace webrtc {
+ namespace videocapturemodule {
+@@ -103,17 +105,13 @@ struct VideoCaptureWinRTInternal {
+   HRESULT StopCapture();
+   bool CaptureStarted();
+ 
+-  HRESULT FrameArrived(
+-      ABI::Windows::Media::Capture::Frames::IMediaFrameReader* sender,
+-      ABI::Windows::Media::Capture::Frames::IMediaFrameArrivedEventArgs* args);
++  HRESULT FrameArrived(IMediaFrameReader* sender,
++                       IMediaFrameArrivedEventArgs* args);
+ 
+  private:
+-  Microsoft::WRL::ComPtr<ABI::Windows::Media::Capture::IMediaCapture>
+-      media_capture_;
++  ComPtr<IMediaCapture> media_capture_;
+ 
+-  Microsoft::WRL::ComPtr<
+-      ABI::Windows::Media::Capture::Frames::IMediaFrameReader>
+-      media_frame_reader_;
++  ComPtr<IMediaFrameReader> media_frame_reader_;
+   EventRegistrationToken media_source_frame_arrived_token;
+ 
+   bool is_capturing = false;
+@@ -125,78 +123,83 @@ VideoCaptureWinRTInternal::VideoCaptureWinRTInternal(
+     : pfn_incoming_frame_(pfn_incoming_frame) {}
+ 
+ VideoCaptureWinRTInternal::~VideoCaptureWinRTInternal() {
+-  HRESULT hr = S_OK;
+-
+   if (media_capture_) {
+     ComPtr<IClosable> closable;
+ 
+-    THR(StopCapture());
+-    THR(media_capture_.As(&closable));
+-    THR(closable->Close());
++    HRESULT hr = StopCapture();
++    if (SUCCEEDED(hr)) {
++      hr = media_capture_.As(&closable);
++    }
++    if (SUCCEEDED(hr)) {
++      hr = closable->Close();
++    }
++    assert(SUCCEEDED(hr));
+   }
+-
+-Cleanup:
+-  assert(SUCCEEDED(hr));
+ }
  
  HRESULT VideoCaptureWinRTInternal::InitCamera(const wchar_t* device_unique_id) {
-   HRESULT hr;
+-  HRESULT hr;
 -  ComPtr<IMediaCaptureInitializationSettings> settings;
 -  ComPtr<IMediaCaptureInitializationSettings5> settings5;
 -  ComPtr<IAsyncAction> async_action;
++  HRESULT hr = S_OK;
    HStringReference device_id(device_unique_id);
  
    if (media_capture_) {
-@@ -153,24 +151,9 @@ HRESULT VideoCaptureWinRTInternal::InitCamera(const wchar_t* device_unique_id) {
-     THR(StopCapture() == 0 ? S_OK : E_FAIL);
-     THR(closable_media_capture->Close());
-   }
+     ComPtr<IClosable> closable_media_capture;
+-    THR(media_capture_.As(&closable_media_capture));
+-
+-    THR(StopCapture() == 0 ? S_OK : E_FAIL);
+-    THR(closable_media_capture->Close());
+-  }
 -  THR(ActivateInstance(
 -      HStringReference(RuntimeClass_Windows_Media_Capture_MediaCapture).Get(),
 -      media_capture_.ReleaseAndGetAddressOf()));
@@ -610,16 +1317,38 @@ index 5aa3541b34..44d7cdca68 100644
 -  THR(settings5->put_MemoryPreference(
 -      MediaCaptureMemoryPreference::MediaCaptureMemoryPreference_Cpu));
 -  THR(settings->put_VideoDeviceId(device_id.Get()));
- 
+-
 -  THR(media_capture_->InitializeWithSettingsAsync(settings.Get(),
 -                                                  &async_action));
 -  THR(WaitForAsyncAction(async_action));
-+  THR(GetMediaCaptureForDevice(device_id.Get(),
-+                                media_capture_.ReleaseAndGetAddressOf()));
- 
- Cleanup:
+-
+-Cleanup:
++
++    if (SUCCEEDED(hr)) {
++      hr = media_capture_.As(&closable_media_capture);
++    }
++
++    if (SUCCEEDED(hr)) {
++      hr = StopCapture() == 0 ? S_OK : E_FAIL;
++    }
++
++    if (SUCCEEDED(hr)) {
++      hr = closable_media_capture->Close();
++    }
++  }
++
++  if (SUCCEEDED(hr)) {
++    hr = GetMediaCaptureForDevice(device_id.Get(), media_capture_);
++  }
++
    return hr;
-@@ -183,7 +166,8 @@ HRESULT VideoCaptureWinRTInternal::StartCapture(
+ }
+ 
+ HRESULT VideoCaptureWinRTInternal::StartCapture(
+     const VideoCaptureCapability& capability) {
+-  HRESULT hr;
++  HRESULT hr = S_OK;
+   ComPtr<IMediaFrameSource> media_frame_source;
    ComPtr<IMediaCapture5> media_capture5;
    ComPtr<IMapView<HSTRING, MediaFrameSource*>> frame_sources;
    ComPtr<IIterable<IKeyValuePair<HSTRING, MediaFrameSource*>*>> iterable;
@@ -629,7 +1358,332 @@ index 5aa3541b34..44d7cdca68 100644
    ComPtr<IAsyncOperation<MediaFrameReader*>> async_operation;
    ComPtr<IAsyncOperation<MediaFrameReaderStartStatus>>
        async_media_frame_reader_start_status;
-@@ -360,9 +344,12 @@ HRESULT VideoCaptureWinRTInternal::FrameArrived(
+   MediaFrameReaderStartStatus media_frame_reader_start_status;
+   boolean has_current;
+ 
+-  THR(media_capture_.As(&media_capture5));
+-  THR(media_capture5->get_FrameSources(&frame_sources));
+-  THR(frame_sources.As(&iterable));
+-  THR(iterable->First(&frame_source_iterator));
+-  THR(frame_source_iterator->get_HasCurrent(&has_current));
++  if (SUCCEEDED(hr)) {
++    hr = media_capture_.As(&media_capture5);
++  }
++
++  if (SUCCEEDED(hr)) {
++    hr = media_capture5->get_FrameSources(&frame_sources);
++  }
++
++  if (SUCCEEDED(hr)) {
++    hr = frame_sources.As(&iterable);
++  }
++
++  if (SUCCEEDED(hr)) {
++    hr = iterable->First(&frame_source_iterator);
++  }
+ 
+-  while (has_current) {
++  if (SUCCEEDED(hr)) {
++    hr = frame_source_iterator->get_HasCurrent(&has_current);
++  }
++
++  while (SUCCEEDED(hr) && has_current) {
+     ComPtr<IKeyValuePair<HSTRING, MediaFrameSource*>> key_value;
+     ComPtr<IMediaFrameSource> value;
+     ComPtr<IMediaFrameSourceInfo> info;
+@@ -208,64 +211,112 @@ HRESULT VideoCaptureWinRTInternal::StartCapture(
+     unsigned int supported_formats_count;
+     UINT32 frame_width, frame_height;
+ 
+-    THR(frame_source_iterator->get_Current(&key_value));
+-    THR(key_value->get_Value(&value));
++    if (SUCCEEDED(hr)) {
++      hr = frame_source_iterator->get_Current(&key_value);
++    }
++
++    if (SUCCEEDED(hr)) {
++      hr = key_value->get_Value(&value);
++    }
+ 
+     // Filters out frame sources other than color video cameras.
+-    THR(value->get_Info(&info));
+-    THR(info->get_MediaStreamType(&media_stream_type));
+-    THR(info->get_SourceKind(&media_frame_source_kind));
+-    if ((media_stream_type != MediaStreamType::MediaStreamType_VideoRecord) ||
+-        (media_frame_source_kind !=
+-         MediaFrameSourceKind::MediaFrameSourceKind_Color)) {
+-      THR(frame_source_iterator->MoveNext(&has_current));
++    if (SUCCEEDED(hr)) {
++      hr = value->get_Info(&info);
++    }
++
++    if (SUCCEEDED(hr)) {
++      hr = info->get_MediaStreamType(&media_stream_type);
++    }
++
++    if (SUCCEEDED(hr)) {
++      hr = info->get_SourceKind(&media_frame_source_kind);
++    }
++
++    if (SUCCEEDED(hr) &&
++        ((media_stream_type != MediaStreamType::MediaStreamType_VideoRecord) ||
++         (media_frame_source_kind !=
++          MediaFrameSourceKind::MediaFrameSourceKind_Color))) {
++      hr = frame_source_iterator->MoveNext(&has_current);
+       continue;
+     }
+ 
+-    THR(value->get_SupportedFormats(&supported_formats));
+-    THR(supported_formats->get_Size(&supported_formats_count));
++    if (SUCCEEDED(hr)) {
++      hr = value->get_SupportedFormats(&supported_formats);
++    }
++
++    if (SUCCEEDED(hr)) {
++      hr = supported_formats->get_Size(&supported_formats_count);
++    }
+ 
+-    for (unsigned int i = 0; i < supported_formats_count; ++i) {
++    for (unsigned int i = 0; SUCCEEDED(hr) && (i < supported_formats_count);
++         ++i) {
+       ComPtr<IMediaFrameFormat> media_frame_format;
+       ComPtr<IAsyncAction> async_action;
+       HString sub_type;
+ 
+-      THR(supported_formats->GetAt(i, &media_frame_format));
++      if (SUCCEEDED(hr)) {
++        hr = supported_formats->GetAt(i, &media_frame_format);
++      }
+ 
+       // Filters out frame sources not sending frames in I420, YUY2, YV12 or
+       // the format requested by the requested capabilities.
+-      THR(media_frame_format->get_Subtype(sub_type.ReleaseAndGetAddressOf()));
+-      VideoType video_type = ToVideoType(sub_type);
+-      if (video_type != capability.videoType &&
+-          video_type != VideoType::kI420 && video_type != VideoType::kYUY2 &&
+-          video_type != VideoType::kYV12) {
+-        continue;
++      if (SUCCEEDED(hr)) {
++        hr = media_frame_format->get_Subtype(sub_type.ReleaseAndGetAddressOf());
++      }
++
++      if (SUCCEEDED(hr)) {
++        VideoType video_type = ToVideoType(sub_type);
++        if (video_type != capability.videoType &&
++            video_type != VideoType::kI420 && video_type != VideoType::kYUY2 &&
++            video_type != VideoType::kYV12) {
++          continue;
++        }
+       }
+ 
+       // Filters out frame sources with resolution different than the one
+       // defined by the requested capabilities.
+-      THR(media_frame_format->get_VideoFormat(&video_media_frame_format));
+-      THR(video_media_frame_format->get_Width(&frame_width));
+-      THR(video_media_frame_format->get_Height(&frame_height));
+-      if ((frame_width != static_cast<UINT32>(capability.width)) ||
+-          (frame_height != static_cast<UINT32>(capability.height))) {
++      if (SUCCEEDED(hr)) {
++        hr = media_frame_format->get_VideoFormat(&video_media_frame_format);
++      }
++
++      if (SUCCEEDED(hr)) {
++        hr = video_media_frame_format->get_Width(&frame_width);
++      }
++
++      if (SUCCEEDED(hr)) {
++        hr = video_media_frame_format->get_Height(&frame_height);
++      }
++
++      if (SUCCEEDED(hr) &&
++          ((frame_width != static_cast<UINT32>(capability.width)) ||
++           (frame_height != static_cast<UINT32>(capability.height)))) {
+         continue;
+       }
+ 
+       // Filters out frames sources with frame rate higher than the what is
+       // requested by the capabilities.
+-      THR(media_frame_format->get_FrameRate(&media_ratio));
+-      if (SafelyComputeMediaRatio(media_ratio.Get()) >
+-          static_cast<uint32_t>(capability.maxFPS)) {
++      if (SUCCEEDED(hr)) {
++        hr = media_frame_format->get_FrameRate(&media_ratio);
++      }
++
++      if (SUCCEEDED(hr) && SafelyComputeMediaRatio(media_ratio.Get()) >
++                               static_cast<uint32_t>(capability.maxFPS)) {
+         continue;
+       }
+ 
+       // Select this as media frame source.
+-      media_frame_source = value;
++      if (SUCCEEDED(hr)) {
++        media_frame_source = value;
++      }
++
++      if (SUCCEEDED(hr)) {
++        hr = media_frame_source->SetFormatAsync(media_frame_format.Get(),
++                                                &async_action);
++      }
+ 
+-      THR(media_frame_source->SetFormatAsync(media_frame_format.Get(),
+-                                             &async_action));
+-      THR(WaitForAsyncAction(async_action));
++      if (SUCCEEDED(hr)) {
++        hr = WaitForAsyncAction(async_action);
++      }
+ 
+       break;
+     }
+@@ -274,44 +325,68 @@ HRESULT VideoCaptureWinRTInternal::StartCapture(
+     // Studio 2 camera has a color source provider and a depth source
+     // provider. We don't need to continue looking for sources once the first
+     // color source provider matches with the configuration we're looking for.
+-    if (media_frame_source) {
++    if (SUCCEEDED(hr) && media_frame_source) {
+       break;
+     }
+   }
+ 
+   // video capture device with capabilities not found
+-  THR(media_frame_source ? S_OK : E_FAIL);
++  if (SUCCEEDED(hr)) {
++    hr = media_frame_source ? S_OK : E_FAIL;
++  }
++
++  if (SUCCEEDED(hr)) {
++    hr = media_capture5->CreateFrameReaderAsync(media_frame_source.Get(),
++                                                &async_operation);
++  }
+ 
+-  THR(media_capture5->CreateFrameReaderAsync(media_frame_source.Get(),
+-                                             &async_operation));
+-  THR(WaitForAsyncOperation(async_operation));
++  if (SUCCEEDED(hr)) {
++    hr = WaitForAsyncOperation(async_operation);
++  }
+ 
+   // Assigns a new media frame reader
+-  THR(async_operation->GetResults(&media_frame_reader_));
+-
+-  THR(media_frame_reader_->add_FrameArrived(
+-      Callback<
+-          ITypedEventHandler<MediaFrameReader*, MediaFrameArrivedEventArgs*>>(
+-          [this](IMediaFrameReader* pSender,
+-                 IMediaFrameArrivedEventArgs* pEventArgs) {
+-            return this->FrameArrived(pSender, pEventArgs);
+-          })
+-          .Get(),
+-      &media_source_frame_arrived_token));
+-
+-  THR(media_frame_reader_->StartAsync(&async_media_frame_reader_start_status));
+-  THR(WaitForAsyncOperation(async_media_frame_reader_start_status));
+-
+-  THR(async_media_frame_reader_start_status->GetResults(
+-      &media_frame_reader_start_status));
+-  THR(media_frame_reader_start_status !=
+-              MediaFrameReaderStartStatus::MediaFrameReaderStartStatus_Success
+-          ? E_FAIL
+-          : S_OK);
+-
+-  is_capturing = true;
+-
+-Cleanup:
++  if (SUCCEEDED(hr)) {
++    hr = async_operation->GetResults(&media_frame_reader_);
++  }
++
++  if (SUCCEEDED(hr)) {
++    hr = media_frame_reader_->add_FrameArrived(
++        Callback<
++            ITypedEventHandler<MediaFrameReader*, MediaFrameArrivedEventArgs*>>(
++            [this](IMediaFrameReader* pSender,
++                   IMediaFrameArrivedEventArgs* pEventArgs) {
++              return this->FrameArrived(pSender, pEventArgs);
++            })
++            .Get(),
++        &media_source_frame_arrived_token);
++  }
++
++  if (SUCCEEDED(hr)) {
++    hr =
++        media_frame_reader_->StartAsync(&async_media_frame_reader_start_status);
++  }
++
++  if (SUCCEEDED(hr)) {
++    hr = WaitForAsyncOperation(async_media_frame_reader_start_status);
++  }
++
++  if (SUCCEEDED(hr)) {
++    hr = async_media_frame_reader_start_status->GetResults(
++        &media_frame_reader_start_status);
++  }
++
++  if (SUCCEEDED(hr)) {
++    hr =
++        media_frame_reader_start_status !=
++                MediaFrameReaderStartStatus::MediaFrameReaderStartStatus_Success
++            ? E_FAIL
++            : S_OK;
++  }
++
++  if (SUCCEEDED(hr)) {
++    is_capturing = true;
++  }
++
+   return hr;
+ }
+ 
+@@ -325,16 +400,26 @@ HRESULT VideoCaptureWinRTInternal::StopCapture() {
+   if (is_capturing) {
+     ComPtr<IAsyncAction> async_action;
+ 
+-    THR(media_frame_reader_->remove_FrameArrived(
+-        media_source_frame_arrived_token));
+-    THR(media_frame_reader_->StopAsync(&async_action));
+-    THR(WaitForAsyncAction(async_action));
++    if (SUCCEEDED(hr)) {
++      hr = media_frame_reader_->remove_FrameArrived(
++          media_source_frame_arrived_token);
++    }
++
++    if (SUCCEEDED(hr)) {
++      hr = media_frame_reader_->StopAsync(&async_action);
++    }
++
++    if (SUCCEEDED(hr)) {
++      hr = WaitForAsyncAction(async_action);
++    }
+   }
+ 
+-  is_capturing = false;
++  if (SUCCEEDED(hr)) {
++    is_capturing = false;
++  }
+ 
+-Cleanup:
+   media_frame_reader_.Reset();
++
+   return hr;
+ }
+ 
+@@ -343,12 +428,11 @@ bool VideoCaptureWinRTInternal::CaptureStarted() {
+ }
+ 
+ HRESULT VideoCaptureWinRTInternal::FrameArrived(
+-    ABI::Windows::Media::Capture::Frames::IMediaFrameReader* sender_no_ref,
+-    ABI::Windows::Media::Capture::Frames::IMediaFrameArrivedEventArgs*
+-        args_no_ref) {
++    IMediaFrameReader* sender_no_ref,
++    IMediaFrameArrivedEventArgs* args_no_ref) {
+   UNREFERENCED_PARAMETER(args_no_ref);
+ 
+-  HRESULT hr;
++  HRESULT hr = S_OK;
+   ComPtr<IMediaFrameReader> media_frame_reader{sender_no_ref};
+   ComPtr<IMediaFrameReference> media_frame_reference;
+   ComPtr<IVideoMediaFrame> video_media_frame;
+@@ -360,42 +444,137 @@ HRESULT VideoCaptureWinRTInternal::FrameArrived(
    ComPtr<IMemoryBuffer> memory_buffer;
    ComPtr<IMemoryBufferReference> memory_buffer_reference;
    ComPtr<IMemoryBufferByteAccess> memory_buffer_byte_access;
@@ -640,55 +1694,162 @@ index 5aa3541b34..44d7cdca68 100644
    uint32_t bitmap_capacity;
 +  int32_t plane_count;
  
-   THR(media_frame_reader->TryAcquireLatestFrame(&media_frame_reference));
+-  THR(media_frame_reader->TryAcquireLatestFrame(&media_frame_reference));
++  if (SUCCEEDED(hr)) {
++    hr = media_frame_reader->TryAcquireLatestFrame(&media_frame_reference);
++  }
  
-@@ -384,15 +371,45 @@ HRESULT VideoCaptureWinRTInternal::FrameArrived(
-     frameInfo.interlaced = false;
+-  if (media_frame_reference) {
+-    THR(media_frame_reference->get_VideoMediaFrame(&video_media_frame));
+-    THR(video_media_frame->get_VideoFormat(&video_media_frame_format));
+-    THR(video_media_frame_format->get_MediaFrameFormat(&media_frame_format));
+-    THR(media_frame_format->get_FrameRate(&media_ratio));
++  if (SUCCEEDED(hr) && media_frame_reference) {
++    hr = media_frame_reference->get_VideoMediaFrame(&video_media_frame);
++
++    if (SUCCEEDED(hr)) {
++      hr = video_media_frame->get_VideoFormat(&video_media_frame_format);
++    }
++
++    if (SUCCEEDED(hr)) {
++      hr = video_media_frame_format->get_MediaFrameFormat(&media_frame_format);
++    }
++
++    if (SUCCEEDED(hr)) {
++      hr = media_frame_format->get_FrameRate(&media_ratio);
++    }
  
-     THR(video_media_frame->get_SoftwareBitmap(&software_bitmap));
-+
-     THR(software_bitmap->LockBuffer(
-         BitmapBufferAccessMode::BitmapBufferAccessMode_Read, &bitmap_buffer));
-+
-+    THR(bitmap_buffer->GetPlaneCount(&plane_count));
-+    THR(plane_count == 2 ? S_OK : E_FAIL);
-+    THR(bitmap_buffer->GetPlaneDescription(0, &bitmap_plane_description_y));
-+    THR(bitmap_buffer->GetPlaneDescription(1, &bitmap_plane_description_uv));
-+
-     THR(bitmap_buffer.As(&memory_buffer));
-     THR(memory_buffer->CreateReference(&memory_buffer_reference));
-     THR(memory_buffer_reference.As(&memory_buffer_byte_access));
-     THR(memory_buffer_byte_access->GetBuffer(&bitmap_content,
-                                              &bitmap_capacity));
- 
+     VideoCaptureCapability frameInfo;
+-    THR(video_media_frame_format->get_Width(
+-        reinterpret_cast<UINT32*>(&frameInfo.width)));
+-    THR(video_media_frame_format->get_Height(
+-        reinterpret_cast<UINT32*>(&frameInfo.height)));
+-    THR(media_frame_format->get_Subtype(
+-        video_subtype.ReleaseAndGetAddressOf()));
+-    frameInfo.videoType = ToVideoType(video_subtype);
+-    frameInfo.maxFPS = SafelyComputeMediaRatio(media_ratio.Get());
+-    frameInfo.interlaced = false;
+-
+-    THR(video_media_frame->get_SoftwareBitmap(&software_bitmap));
+-    THR(software_bitmap->LockBuffer(
+-        BitmapBufferAccessMode::BitmapBufferAccessMode_Read, &bitmap_buffer));
+-    THR(bitmap_buffer.As(&memory_buffer));
+-    THR(memory_buffer->CreateReference(&memory_buffer_reference));
+-    THR(memory_buffer_reference.As(&memory_buffer_byte_access));
+-    THR(memory_buffer_byte_access->GetBuffer(&bitmap_content,
+-                                             &bitmap_capacity));
+-
 -    pfn_incoming_frame_(bitmap_content, bitmap_capacity, frameInfo, 0);
-+    // workaround(auright): The following code works around the limitations of 
-+    // libWebRTC memory representations for YUV planar images. Windows::Media::Capture allows
-+    // representing NV12 images with strides greater than YUV widths and with a gap between
-+    // the Y plane and the UV planes. The following workaround compresses the image in memory
-+    // by removing the gap between planes and making the stride equal to widths. This is a
-+    // temporary workaround until the implementation with Media Foundation is in place.
-+    if ((bitmap_plane_description_y.Width != bitmap_plane_description_y.Stride) ||
-+        (bitmap_plane_description_uv.Width * 2 != bitmap_plane_description_uv.Stride) ||
-+        (bitmap_plane_description_y.Width * bitmap_plane_description_y.Height != bitmap_plane_description_uv.StartIndex)) {
-+        uint8_t* pContiguousYUV = bitmap_content + bitmap_plane_description_y.Width;
+-  }
+-
+-Cleanup:
++
++    if (SUCCEEDED(hr)) {
++      hr = video_media_frame_format->get_Width(
++          reinterpret_cast<UINT32*>(&frameInfo.width));
++    }
++
++    if (SUCCEEDED(hr)) {
++      hr = video_media_frame_format->get_Height(
++          reinterpret_cast<UINT32*>(&frameInfo.height));
++    }
++
++    if (SUCCEEDED(hr)) {
++      hr = media_frame_format->get_Subtype(
++          video_subtype.ReleaseAndGetAddressOf());
++    }
++
++    if (SUCCEEDED(hr)) {
++      frameInfo.videoType = ToVideoType(video_subtype);
++      frameInfo.maxFPS = SafelyComputeMediaRatio(media_ratio.Get());
++      frameInfo.interlaced = false;
++    }
++
++    if (SUCCEEDED(hr)) {
++      hr = video_media_frame->get_SoftwareBitmap(&software_bitmap);
++    }
++
++    if (SUCCEEDED(hr)) {
++      hr = software_bitmap->LockBuffer(
++          BitmapBufferAccessMode::BitmapBufferAccessMode_Read, &bitmap_buffer);
++    }
++
++    if (SUCCEEDED(hr)) {
++      hr = bitmap_buffer->GetPlaneCount(&plane_count);
++    }
++
++    if (SUCCEEDED(hr)) {
++      hr = plane_count == 2 ? S_OK : E_FAIL;
++    }
++
++    if (SUCCEEDED(hr)) {
++      hr = bitmap_buffer->GetPlaneDescription(0, &bitmap_plane_description_y);
++    }
++
++    if (SUCCEEDED(hr)) {
++      hr = bitmap_buffer->GetPlaneDescription(1, &bitmap_plane_description_uv);
++    }
++
++    if (SUCCEEDED(hr)) {
++      hr = bitmap_buffer.As(&memory_buffer);
++    }
++
++    if (SUCCEEDED(hr)) {
++      hr = memory_buffer->CreateReference(&memory_buffer_reference);
++    }
++
++    if (SUCCEEDED(hr)) {
++      hr = memory_buffer_reference.As(&memory_buffer_byte_access);
++    }
++
++    if (SUCCEEDED(hr)) {
++      hr = memory_buffer_byte_access->GetBuffer(&bitmap_content,
++                                                &bitmap_capacity);
++    }
++
++    // workaround(auright): The following code works around the limitations of
++    // libWebRTC memory representations for YUV planar images.
++    // Windows::Media::Capture allows representing NV12 images with strides
++    // greater than YUV widths and with a gap between the Y plane and the UV
++    // planes. The following workaround compresses the image in memory by
++    // removing the gap between planes and making the stride equal to widths.
++    // This is a temporary workaround until the implementation with Media
++    // Foundation is in place.
++    if (SUCCEEDED(hr)) {
++      if ((bitmap_plane_description_y.Width !=
++           bitmap_plane_description_y.Stride) ||
++          (bitmap_plane_description_uv.Width * 2 !=
++           bitmap_plane_description_uv.Stride) ||
++          (bitmap_plane_description_y.Width *
++               bitmap_plane_description_y.Height !=
++           bitmap_plane_description_uv.StartIndex)) {
++        uint8_t* pContiguousYUV =
++            bitmap_content + bitmap_plane_description_y.Width;
 +        for (auto i = 1; i < bitmap_plane_description_y.Height; ++i) {
-+          memcpy(pContiguousYUV, bitmap_content + (i * bitmap_plane_description_y.Stride), bitmap_plane_description_y.Width);
++          memcpy(pContiguousYUV,
++                 bitmap_content + (i * bitmap_plane_description_y.Stride),
++                 bitmap_plane_description_y.Width);
 +          pContiguousYUV += bitmap_plane_description_y.Width;
 +        }
 +        for (auto i = 0; i < bitmap_plane_description_uv.Height; ++i) {
-+          memcpy(pContiguousYUV, bitmap_content + bitmap_plane_description_uv.StartIndex + (i * bitmap_plane_description_uv.Stride), bitmap_plane_description_uv.Width * 2);
++          memcpy(pContiguousYUV,
++                 bitmap_content + bitmap_plane_description_uv.StartIndex +
++                     (i * bitmap_plane_description_uv.Stride),
++                 bitmap_plane_description_uv.Width * 2);
 +          pContiguousYUV += bitmap_plane_description_uv.Width * 2;
 +        }
 +
-+        pfn_incoming_frame_(bitmap_content, pContiguousYUV - bitmap_content, frameInfo, 0);
-+    } else {
-+      pfn_incoming_frame_(bitmap_content, bitmap_capacity, frameInfo, 0);
++        pfn_incoming_frame_(bitmap_content, pContiguousYUV - bitmap_content,
++                            frameInfo, 0);
++      } else {
++        pfn_incoming_frame_(bitmap_content, bitmap_capacity, frameInfo, 0);
++      }
 +    }
++  }
 +
-   }
- 
- Cleanup:
+   if (memory_buffer_reference) {
+     ComPtr<IClosable> closable;
+     memory_buffer_reference.As(&closable);
 -- 
 2.26.2.windows.1
 

--- a/patches_for_WebRTC_org/m80/0007.2-Properly-handling-async-model-for-initializing-Media.patch
+++ b/patches_for_WebRTC_org/m80/0007.2-Properly-handling-async-model-for-initializing-Media.patch
@@ -1,15 +1,16 @@
-From df0d8cdd106d67bc3757cc4ef74c693acec3d5cc Mon Sep 17 00:00:00 2001
+From 8169d726cdc4ef049d6ef64e202e07e3bb58ee3b Mon Sep 17 00:00:00 2001
 From: Augusto Righetto <aurighet@microsoft.com>
 Date: Wed, 27 May 2020 23:38:26 -0700
 Subject: [PATCH] Properly handling async model for initializing MediaCapture
  object
 
+Working around the stride and gap issues with NV12 memory layout
 ---
  .../windows/device_info_winrt.cc              | 178 ++++++----------
  .../windows/help_functions_winrt.cc           | 199 +++++++++++++++++-
  .../windows/help_functions_winrt.h            |  54 ++++-
- .../windows/video_capture_winrt.cc            |  25 +--
- 4 files changed, 308 insertions(+), 148 deletions(-)
+ .../windows/video_capture_winrt.cc            |  61 ++++--
+ 4 files changed, 343 insertions(+), 149 deletions(-)
 
 diff --git a/modules/video_capture/windows/device_info_winrt.cc b/modules/video_capture/windows/device_info_winrt.cc
 index 3b2a7aa773..2a7676be1a 100644
@@ -571,10 +572,18 @@ index 0216d9b0ce..6b81bfc977 100644
      Microsoft::WRL::ComPtr<ABI::Windows::Foundation::IAsyncAction>
          async_action);
 diff --git a/modules/video_capture/windows/video_capture_winrt.cc b/modules/video_capture/windows/video_capture_winrt.cc
-index 5aa3541b34..5cc6154837 100644
+index 5aa3541b34..4a8a597bdf 100644
 --- a/modules/video_capture/windows/video_capture_winrt.cc
 +++ b/modules/video_capture/windows/video_capture_winrt.cc
-@@ -141,9 +141,6 @@ Cleanup:
+@@ -68,6 +68,7 @@ using ABI::Windows::Media::Capture::Frames::MediaFrameReaderStartStatus;
+ using ABI::Windows::Media::Capture::Frames::MediaFrameSource;
+ using ABI::Windows::Media::Capture::Frames::MediaFrameSourceKind;
+ using ABI::Windows::Media::MediaProperties::IMediaRatio;
++using ABI::Windows::Graphics::Imaging::BitmapPlaneDescription;
+ using Microsoft::WRL::Callback;
+ using Microsoft::WRL::ComPtr;
+ using Microsoft::WRL::Wrappers::HString;
+@@ -141,9 +142,6 @@ Cleanup:
  
  HRESULT VideoCaptureWinRTInternal::InitCamera(const wchar_t* device_unique_id) {
    HRESULT hr;
@@ -584,7 +593,7 @@ index 5aa3541b34..5cc6154837 100644
    HStringReference device_id(device_unique_id);
  
    if (media_capture_) {
-@@ -153,24 +150,9 @@ HRESULT VideoCaptureWinRTInternal::InitCamera(const wchar_t* device_unique_id) {
+@@ -153,24 +151,9 @@ HRESULT VideoCaptureWinRTInternal::InitCamera(const wchar_t* device_unique_id) {
      THR(StopCapture() == 0 ? S_OK : E_FAIL);
      THR(closable_media_capture->Close());
    }
@@ -611,7 +620,7 @@ index 5aa3541b34..5cc6154837 100644
  
  Cleanup:
    return hr;
-@@ -183,7 +165,8 @@ HRESULT VideoCaptureWinRTInternal::StartCapture(
+@@ -183,7 +166,8 @@ HRESULT VideoCaptureWinRTInternal::StartCapture(
    ComPtr<IMediaCapture5> media_capture5;
    ComPtr<IMapView<HSTRING, MediaFrameSource*>> frame_sources;
    ComPtr<IIterable<IKeyValuePair<HSTRING, MediaFrameSource*>*>> iterable;
@@ -621,6 +630,66 @@ index 5aa3541b34..5cc6154837 100644
    ComPtr<IAsyncOperation<MediaFrameReader*>> async_operation;
    ComPtr<IAsyncOperation<MediaFrameReaderStartStatus>>
        async_media_frame_reader_start_status;
+@@ -360,9 +344,12 @@ HRESULT VideoCaptureWinRTInternal::FrameArrived(
+   ComPtr<IMemoryBuffer> memory_buffer;
+   ComPtr<IMemoryBufferReference> memory_buffer_reference;
+   ComPtr<IMemoryBufferByteAccess> memory_buffer_byte_access;
++  BitmapPlaneDescription bitmap_plane_description_y;
++  BitmapPlaneDescription bitmap_plane_description_uv;
+   HString video_subtype;
+   uint8_t* bitmap_content;
+   uint32_t bitmap_capacity;
++  int32_t plane_count;
+ 
+   THR(media_frame_reader->TryAcquireLatestFrame(&media_frame_reference));
+ 
+@@ -384,15 +371,45 @@ HRESULT VideoCaptureWinRTInternal::FrameArrived(
+     frameInfo.interlaced = false;
+ 
+     THR(video_media_frame->get_SoftwareBitmap(&software_bitmap));
++
+     THR(software_bitmap->LockBuffer(
+         BitmapBufferAccessMode::BitmapBufferAccessMode_Read, &bitmap_buffer));
++
++    THR(bitmap_buffer->GetPlaneCount(&plane_count));
++    THR(plane_count == 2 ? S_OK : E_FAIL);
++    THR(bitmap_buffer->GetPlaneDescription(0, &bitmap_plane_description_y));
++    THR(bitmap_buffer->GetPlaneDescription(1, &bitmap_plane_description_uv));
++
+     THR(bitmap_buffer.As(&memory_buffer));
+     THR(memory_buffer->CreateReference(&memory_buffer_reference));
+     THR(memory_buffer_reference.As(&memory_buffer_byte_access));
+     THR(memory_buffer_byte_access->GetBuffer(&bitmap_content,
+                                              &bitmap_capacity));
+ 
+-    pfn_incoming_frame_(bitmap_content, bitmap_capacity, frameInfo, 0);
++    // hack(auright): The following hack works around the limitations of 
++    // libWebRTC memory representations for YUV planar images. Windows::Media::Capture allows
++    // representing NV12 images with strides greater than YUV widths and with a gap between
++    // the Y plane and the UV planes. The following workaround compresses the image in memory
++    // by removing the gap between planes and making the stride equal to widths. This is a
++    // temporary hack until the implementation with Media Foundation is in place.
++    if ((bitmap_plane_description_y.Width != bitmap_plane_description_y.Stride) ||
++        (bitmap_plane_description_uv.Width * 2 != bitmap_plane_description_uv.Stride) ||
++        (bitmap_plane_description_y.Width * bitmap_plane_description_y.Height != bitmap_plane_description_uv.StartIndex)) {
++        uint8_t* pContiguousYUV = bitmap_content + bitmap_plane_description_y.Width;
++        for (auto i = 1; i < bitmap_plane_description_y.Height; ++i) {
++          memcpy(pContiguousYUV, bitmap_content + (i * bitmap_plane_description_y.Stride), bitmap_plane_description_y.Width);
++          pContiguousYUV += bitmap_plane_description_y.Width;
++        }
++        for (auto i = 0; i < bitmap_plane_description_uv.Height; ++i) {
++          memcpy(pContiguousYUV, bitmap_content + bitmap_plane_description_uv.StartIndex + (i * bitmap_plane_description_uv.Stride), bitmap_plane_description_uv.Width * 2);
++          pContiguousYUV += bitmap_plane_description_uv.Width * 2;
++        }
++
++        pfn_incoming_frame_(bitmap_content, pContiguousYUV - bitmap_content, frameInfo, 0);
++    } else {
++      pfn_incoming_frame_(bitmap_content, bitmap_capacity, frameInfo, 0);
++    }
++
+   }
+ 
+ Cleanup:
 -- 
-2.21.0.windows.1
+2.26.2.windows.1
 

--- a/patches_for_WebRTC_org/m80/0007.2-Properly-handling-async-model-for-initializing-Media.patch
+++ b/patches_for_WebRTC_org/m80/0007.2-Properly-handling-async-model-for-initializing-Media.patch
@@ -1,4 +1,4 @@
-From c48576f03202179141476832cba6a76b4f4eddd7 Mon Sep 17 00:00:00 2001
+From 69bfd0c42bb4d21b158497d71f1bb0dd12884467 Mon Sep 17 00:00:00 2001
 From: Augusto Righetto <aurighet@microsoft.com>
 Date: Wed, 27 May 2020 23:38:26 -0700
 Subject: [PATCH] Properly handling async model for initializing MediaCapture
@@ -20,13 +20,93 @@ device_info_winrt, repent for the goto sins
 No more goto or THR sins
 
 Not using ReleaseInterface anymore
+
+Passing YUV strides and gap down to libyuv
 ---
+ modules/video_capture/video_capture_impl.cc   |  28 +-
+ modules/video_capture/video_capture_impl.h    |   5 +-
  .../windows/device_info_winrt.cc              | 402 +++++++------
  .../windows/help_functions_winrt.cc           | 335 +++++++++--
  .../windows/help_functions_winrt.h            | 123 ++--
- .../windows/video_capture_winrt.cc            | 565 ++++++++++++------
- 4 files changed, 937 insertions(+), 488 deletions(-)
+ .../windows/video_capture_winrt.cc            | 562 +++++++++++-------
+ 6 files changed, 943 insertions(+), 512 deletions(-)
 
+diff --git a/modules/video_capture/video_capture_impl.cc b/modules/video_capture/video_capture_impl.cc
+index 9d53a91157..398e41c07b 100644
+--- a/modules/video_capture/video_capture_impl.cc
++++ b/modules/video_capture/video_capture_impl.cc
+@@ -114,7 +114,10 @@ int32_t VideoCaptureImpl::DeliverCapturedFrame(VideoFrame& captureFrame) {
+   return 0;
+ }
+ 
+-int32_t VideoCaptureImpl::IncomingFrame(uint8_t* videoFrame,
++int32_t VideoCaptureImpl::IncomingFrame(uint8_t* plane_y,
++                                        int32_t stride_y,
++                                        uint8_t* plane_uv,
++                                        int32_t stride_uv,
+                                         size_t videoFrameLength,
+                                         const VideoCaptureCapability& frameInfo,
+                                         int64_t captureTime /*=0*/) {
+@@ -125,16 +128,8 @@ int32_t VideoCaptureImpl::IncomingFrame(uint8_t* videoFrame,
+ 
+   TRACE_EVENT1("webrtc", "VC::IncomingFrame", "capture_time", captureTime);
+ 
+-  // Not encoded, convert to I420.
+-  if (frameInfo.videoType != VideoType::kMJPEG &&
+-      CalcBufferSize(frameInfo.videoType, width, abs(height)) !=
+-          videoFrameLength) {
+-    RTC_LOG(LS_ERROR) << "Wrong incoming frame length.";
+-    return -1;
+-  }
+-
+-  int stride_y = width;
+-  int stride_uv = (width + 1) / 2;
++  int dst_stride_y = width;
++  int dst_stride_uv = (width + 1) / 2;
+   int target_width = width;
+   int target_height = abs(height);
+ 
+@@ -156,7 +151,7 @@ int32_t VideoCaptureImpl::IncomingFrame(uint8_t* videoFrame,
+ 
+   // TODO(nisse): Use a pool?
+   rtc::scoped_refptr<I420Buffer> buffer = I420Buffer::Create(
+-      target_width, target_height, stride_y, stride_uv, stride_uv);
++      target_width, target_height, dst_stride_y, dst_stride_uv, dst_stride_uv);
+ 
+   libyuv::RotationMode rotation_mode = libyuv::kRotate0;
+   if (apply_rotation) {
+@@ -177,10 +172,11 @@ int32_t VideoCaptureImpl::IncomingFrame(uint8_t* videoFrame,
+   }
+ 
+   const int conversionResult = libyuv::ConvertToI420(
+-      videoFrame, videoFrameLength, buffer.get()->MutableDataY(),
+-      buffer.get()->StrideY(), buffer.get()->MutableDataU(),
+-      buffer.get()->StrideU(), buffer.get()->MutableDataV(),
+-      buffer.get()->StrideV(), 0, 0,  // No Cropping
++      plane_y, videoFrameLength, stride_y, plane_uv, stride_uv,
++      buffer.get()->MutableDataY(), buffer.get()->StrideY(),
++      buffer.get()->MutableDataU(), buffer.get()->StrideU(),
++      buffer.get()->MutableDataV(), buffer.get()->StrideV(), 0,
++      0,  // No Cropping
+       width, height, target_width, target_height, rotation_mode,
+       ConvertVideoType(frameInfo.videoType));
+   if (conversionResult < 0) {
+diff --git a/modules/video_capture/video_capture_impl.h b/modules/video_capture/video_capture_impl.h
+index 197bfd387c..ed687106b9 100644
+--- a/modules/video_capture/video_capture_impl.h
++++ b/modules/video_capture/video_capture_impl.h
+@@ -62,7 +62,10 @@ class VideoCaptureImpl : public VideoCaptureModule {
+   const char* CurrentDeviceName() const override;
+ 
+   // |capture_time| must be specified in NTP time format in milliseconds.
+-  int32_t IncomingFrame(uint8_t* videoFrame,
++  int32_t IncomingFrame(uint8_t* plane_y,
++                        int32_t stride_y,
++                        uint8_t* plane_uv,
++                        int32_t stride_uv,
+                         size_t videoFrameLength,
+                         const VideoCaptureCapability& frameInfo,
+                         int64_t captureTime = 0);
 diff --git a/modules/video_capture/windows/device_info_winrt.cc b/modules/video_capture/windows/device_info_winrt.cc
 index 3b2a7aa773..3e21c292cc 100644
 --- a/modules/video_capture/windows/device_info_winrt.cc
@@ -1148,7 +1228,7 @@ index 0216d9b0ce..9dae10bcf0 100644
  }
  
 diff --git a/modules/video_capture/windows/video_capture_winrt.cc b/modules/video_capture/windows/video_capture_winrt.cc
-index 5aa3541b34..9a8c58c74f 100644
+index 5aa3541b34..a41fccfdb1 100644
 --- a/modules/video_capture/windows/video_capture_winrt.cc
 +++ b/modules/video_capture/windows/video_capture_winrt.cc
 @@ -32,46 +32,48 @@ struct __declspec(uuid("5b0d3235-4dba-4d44-865e-8f1d0e4fd04d")) __declspec(
@@ -1240,7 +1320,34 @@ index 5aa3541b34..9a8c58c74f 100644
  
  namespace webrtc {
  namespace videocapturemodule {
-@@ -103,17 +105,13 @@ struct VideoCaptureWinRTInternal {
+@@ -83,12 +85,20 @@ namespace videocapturemodule {
+ ///////////////////////////////////////////////////////////////////////////////
+ 
+ // Callback type for the following method:
+-// int32_t VideoCaptureImpl::IncomingFrame(uint8_t* videoFrame,
+-//                     size_t videoFrameLength,
+-//                     const VideoCaptureCapability& frameInfo,
+-//                     int64_t captureTime = 0);
+-typedef std::function<
+-    int32_t(uint8_t*, size_t, const VideoCaptureCapability&, int64_t)>
++// int32_t VideoCaptureImpl::IncomingFrame(uint8_t *plane_y,
++//                                         int32_t stride_y,
++//                                         uint8_t *plane_uv,
++//                                         int32_t stride_uv,
++//                                         size_t videoFrameLength,
++//                                         const VideoCaptureCapability
++//                                         &frameInfo, int64_t captureTime = 0
++typedef std::function<int32_t(uint8_t*,
++                              int32_t,
++                              uint8_t*,
++                              int32_t,
++                              size_t,
++                              const VideoCaptureCapability&,
++                              int64_t)>
+     PFNIncomingFrameType;
+ 
+ struct VideoCaptureWinRTInternal {
+@@ -103,17 +113,13 @@ struct VideoCaptureWinRTInternal {
    HRESULT StopCapture();
    bool CaptureStarted();
  
@@ -1262,7 +1369,7 @@ index 5aa3541b34..9a8c58c74f 100644
    EventRegistrationToken media_source_frame_arrived_token;
  
    bool is_capturing = false;
-@@ -125,78 +123,83 @@ VideoCaptureWinRTInternal::VideoCaptureWinRTInternal(
+@@ -125,78 +131,83 @@ VideoCaptureWinRTInternal::VideoCaptureWinRTInternal(
      : pfn_incoming_frame_(pfn_incoming_frame) {}
  
  VideoCaptureWinRTInternal::~VideoCaptureWinRTInternal() {
@@ -1377,12 +1484,12 @@ index 5aa3541b34..9a8c58c74f 100644
 +  if (SUCCEEDED(hr)) {
 +    hr = frame_sources.As(&iterable);
 +  }
-+
+ 
+-  while (has_current) {
 +  if (SUCCEEDED(hr)) {
 +    hr = iterable->First(&frame_source_iterator);
 +  }
- 
--  while (has_current) {
++
 +  if (SUCCEEDED(hr)) {
 +    hr = frame_source_iterator->get_HasCurrent(&has_current);
 +  }
@@ -1391,7 +1498,7 @@ index 5aa3541b34..9a8c58c74f 100644
      ComPtr<IKeyValuePair<HSTRING, MediaFrameSource*>> key_value;
      ComPtr<IMediaFrameSource> value;
      ComPtr<IMediaFrameSourceInfo> info;
-@@ -208,64 +211,112 @@ HRESULT VideoCaptureWinRTInternal::StartCapture(
+@@ -208,64 +219,112 @@ HRESULT VideoCaptureWinRTInternal::StartCapture(
      unsigned int supported_formats_count;
      UINT32 frame_width, frame_height;
  
@@ -1520,22 +1627,22 @@ index 5aa3541b34..9a8c58c74f 100644
 +      if (SUCCEEDED(hr)) {
 +        media_frame_source = value;
 +      }
-+
-+      if (SUCCEEDED(hr)) {
-+        hr = media_frame_source->SetFormatAsync(media_frame_format.Get(),
-+                                                &async_action);
-+      }
  
 -      THR(media_frame_source->SetFormatAsync(media_frame_format.Get(),
 -                                             &async_action));
 -      THR(WaitForAsyncAction(async_action));
++      if (SUCCEEDED(hr)) {
++        hr = media_frame_source->SetFormatAsync(media_frame_format.Get(),
++                                                &async_action);
++      }
++
 +      if (SUCCEEDED(hr)) {
 +        hr = WaitForAsyncAction(async_action);
 +      }
  
        break;
      }
-@@ -274,44 +325,68 @@ HRESULT VideoCaptureWinRTInternal::StartCapture(
+@@ -274,44 +333,68 @@ HRESULT VideoCaptureWinRTInternal::StartCapture(
      // Studio 2 camera has a color source provider and a depth source
      // provider. We don't need to continue looking for sources once the first
      // color source provider matches with the configuration we're looking for.
@@ -1550,15 +1657,15 @@ index 5aa3541b34..9a8c58c74f 100644
 +  if (SUCCEEDED(hr)) {
 +    hr = media_frame_source ? S_OK : E_FAIL;
 +  }
-+
-+  if (SUCCEEDED(hr)) {
-+    hr = media_capture5->CreateFrameReaderAsync(media_frame_source.Get(),
-+                                                &async_operation);
-+  }
  
 -  THR(media_capture5->CreateFrameReaderAsync(media_frame_source.Get(),
 -                                             &async_operation));
 -  THR(WaitForAsyncOperation(async_operation));
++  if (SUCCEEDED(hr)) {
++    hr = media_capture5->CreateFrameReaderAsync(media_frame_source.Get(),
++                                                &async_operation);
++  }
++
 +  if (SUCCEEDED(hr)) {
 +    hr = WaitForAsyncOperation(async_operation);
 +  }
@@ -1634,7 +1741,7 @@ index 5aa3541b34..9a8c58c74f 100644
    return hr;
  }
  
-@@ -325,16 +400,26 @@ HRESULT VideoCaptureWinRTInternal::StopCapture() {
+@@ -325,16 +408,26 @@ HRESULT VideoCaptureWinRTInternal::StopCapture() {
    if (is_capturing) {
      ComPtr<IAsyncAction> async_action;
  
@@ -1667,7 +1774,7 @@ index 5aa3541b34..9a8c58c74f 100644
    return hr;
  }
  
-@@ -343,12 +428,11 @@ bool VideoCaptureWinRTInternal::CaptureStarted() {
+@@ -343,12 +436,11 @@ bool VideoCaptureWinRTInternal::CaptureStarted() {
  }
  
  HRESULT VideoCaptureWinRTInternal::FrameArrived(
@@ -1683,7 +1790,7 @@ index 5aa3541b34..9a8c58c74f 100644
    ComPtr<IMediaFrameReader> media_frame_reader{sender_no_ref};
    ComPtr<IMediaFrameReference> media_frame_reference;
    ComPtr<IVideoMediaFrame> video_media_frame;
-@@ -360,42 +444,137 @@ HRESULT VideoCaptureWinRTInternal::FrameArrived(
+@@ -360,42 +452,109 @@ HRESULT VideoCaptureWinRTInternal::FrameArrived(
    ComPtr<IMemoryBuffer> memory_buffer;
    ComPtr<IMemoryBufferReference> memory_buffer_reference;
    ComPtr<IMemoryBufferByteAccess> memory_buffer_byte_access;
@@ -1807,49 +1914,33 @@ index 5aa3541b34..9a8c58c74f 100644
 +                                                &bitmap_capacity);
 +    }
 +
-+    // workaround(auright): The following code works around the limitations of
-+    // libWebRTC memory representations for YUV planar images.
-+    // Windows::Media::Capture allows representing NV12 images with strides
-+    // greater than YUV widths and with a gap between the Y plane and the UV
-+    // planes. The following workaround compresses the image in memory by
-+    // removing the gap between planes and making the stride equal to widths.
-+    // This is a temporary workaround until the implementation with Media
-+    // Foundation is in place.
 +    if (SUCCEEDED(hr)) {
-+      if ((bitmap_plane_description_y.Width !=
-+           bitmap_plane_description_y.Stride) ||
-+          (bitmap_plane_description_uv.Width * 2 !=
-+           bitmap_plane_description_uv.Stride) ||
-+          (bitmap_plane_description_y.Width *
-+               bitmap_plane_description_y.Height !=
-+           bitmap_plane_description_uv.StartIndex)) {
-+        uint8_t* pContiguousYUV =
-+            bitmap_content + bitmap_plane_description_y.Width;
-+        for (auto i = 1; i < bitmap_plane_description_y.Height; ++i) {
-+          memcpy(pContiguousYUV,
-+                 bitmap_content + (i * bitmap_plane_description_y.Stride),
-+                 bitmap_plane_description_y.Width);
-+          pContiguousYUV += bitmap_plane_description_y.Width;
-+        }
-+        for (auto i = 0; i < bitmap_plane_description_uv.Height; ++i) {
-+          memcpy(pContiguousYUV,
-+                 bitmap_content + bitmap_plane_description_uv.StartIndex +
-+                     (i * bitmap_plane_description_uv.Stride),
-+                 bitmap_plane_description_uv.Width * 2);
-+          pContiguousYUV += bitmap_plane_description_uv.Width * 2;
-+        }
-+
-+        pfn_incoming_frame_(bitmap_content, pContiguousYUV - bitmap_content,
-+                            frameInfo, 0);
-+      } else {
-+        pfn_incoming_frame_(bitmap_content, bitmap_capacity, frameInfo, 0);
-+      }
++      pfn_incoming_frame_(
++          bitmap_content,                                           // Plane Y
++          bitmap_plane_description_y.Stride,                        // Stride Y
++          bitmap_content + bitmap_plane_description_uv.StartIndex,  // Plane UV
++          bitmap_plane_description_uv.Stride,                       // Stride UV
++          bitmap_capacity,  // YUV buffer size
++          frameInfo,        // Y Width and Height
++          0);               // Capture Time
 +    }
 +  }
 +
    if (memory_buffer_reference) {
      ComPtr<IClosable> closable;
      memory_buffer_reference.As(&closable);
+@@ -441,7 +600,10 @@ VideoCaptureWinRT::VideoCaptureWinRT()
+                     std::placeholders::_1,
+                     std::placeholders::_2,
+                     std::placeholders::_3,
+-                    std::placeholders::_4))) {}
++                    std::placeholders::_4,
++                    std::placeholders::_5,
++                    std::placeholders::_6,
++                    std::placeholders::_7))) {}
+ 
+ VideoCaptureWinRT::~VideoCaptureWinRT() {
+   delete Impl(video_capture_internal_);
 -- 
-2.26.2.windows.1
+2.21.0.windows.1
 

--- a/patches_for_WebRTC_org/m80/0007.2-Properly-handling-async-model-for-initializing-Media.patch
+++ b/patches_for_WebRTC_org/m80/0007.2-Properly-handling-async-model-for-initializing-Media.patch
@@ -1,0 +1,626 @@
+From df0d8cdd106d67bc3757cc4ef74c693acec3d5cc Mon Sep 17 00:00:00 2001
+From: Augusto Righetto <aurighet@microsoft.com>
+Date: Wed, 27 May 2020 23:38:26 -0700
+Subject: [PATCH] Properly handling async model for initializing MediaCapture
+ object
+
+---
+ .../windows/device_info_winrt.cc              | 178 ++++++----------
+ .../windows/help_functions_winrt.cc           | 199 +++++++++++++++++-
+ .../windows/help_functions_winrt.h            |  54 ++++-
+ .../windows/video_capture_winrt.cc            |  25 +--
+ 4 files changed, 308 insertions(+), 148 deletions(-)
+
+diff --git a/modules/video_capture/windows/device_info_winrt.cc b/modules/video_capture/windows/device_info_winrt.cc
+index 3b2a7aa773..2a7676be1a 100644
+--- a/modules/video_capture/windows/device_info_winrt.cc
++++ b/modules/video_capture/windows/device_info_winrt.cc
+@@ -26,34 +26,49 @@
+ #include "rtc_base/logging.h"
+ #include "rtc_base/string_utils.h"
+ 
+-using ABI::Windows::Devices::Enumeration::DeviceClass;
+-using ABI::Windows::Devices::Enumeration::DeviceClass_VideoCapture;
+-using ABI::Windows::Devices::Enumeration::DeviceInformation;
+-using ABI::Windows::Devices::Enumeration::DeviceInformationCollection;
+-using ABI::Windows::Devices::Enumeration::IDeviceInformation;
+-using ABI::Windows::Devices::Enumeration::IDeviceInformationStatics;
+-using ABI::Windows::Foundation::ActivateInstance;
+-using ABI::Windows::Foundation::GetActivationFactory;
+-using ABI::Windows::Foundation::IAsyncAction;
+-using ABI::Windows::Foundation::IAsyncOperation;
+-using ABI::Windows::Foundation::IClosable;
+-using ABI::Windows::Foundation::Collections::IVectorView;
+-using ABI::Windows::Media::Capture::IMediaCapture;
+-using ABI::Windows::Media::Capture::IMediaCaptureInitializationSettings;
+-using ABI::Windows::Media::Capture::IMediaCaptureInitializationSettings5;
+-using ABI::Windows::Media::Capture::MediaCaptureMemoryPreference;
+-using ABI::Windows::Media::Capture::MediaStreamType;
+-using ABI::Windows::Media::Capture::StreamingCaptureMode;
+-using ABI::Windows::Media::Devices::IMediaDeviceController;
+-using ABI::Windows::Media::Devices::IVideoDeviceController;
+-using ABI::Windows::Media::MediaProperties::IMediaEncodingProperties;
+-using ABI::Windows::Media::MediaProperties::IMediaRatio;
+-using ABI::Windows::Media::MediaProperties::IVideoEncodingProperties;
+-using Microsoft::WRL::ComPtr;
+-using Microsoft::WRL::Wrappers::HString;
+-using Microsoft::WRL::Wrappers::HStringReference;
+-using Microsoft::WRL::Wrappers::RoInitializeWrapper;
+-using std::vector;
++using ::ABI::Windows::ApplicationModel::Core::ICoreApplication;
++using ::ABI::Windows::ApplicationModel::Core::ICoreApplicationView;
++using ::ABI::Windows::ApplicationModel::Core::ICoreImmersiveApplication;
++using ::ABI::Windows::Devices::Enumeration::DeviceClass;
++using ::ABI::Windows::Devices::Enumeration::DeviceClass_VideoCapture;
++using ::ABI::Windows::Devices::Enumeration::DeviceInformation;
++using ::ABI::Windows::Devices::Enumeration::DeviceInformationCollection;
++using ::ABI::Windows::Devices::Enumeration::IDeviceInformation;
++using ::ABI::Windows::Devices::Enumeration::IDeviceInformationStatics;
++using ::ABI::Windows::Foundation::ActivateInstance;
++using ::ABI::Windows::Foundation::GetActivationFactory;
++using ::ABI::Windows::Foundation::IAsyncAction;
++using ::ABI::Windows::Foundation::IAsyncActionCompletedHandler;
++using ::ABI::Windows::Foundation::IAsyncOperation;
++using ::ABI::Windows::Foundation::IClosable;
++using ::ABI::Windows::Foundation::Collections::IVectorView;
++using ::ABI::Windows::Media::Capture::IMediaCapture;
++using ::ABI::Windows::Media::Capture::IMediaCaptureInitializationSettings;
++using ::ABI::Windows::Media::Capture::IMediaCaptureInitializationSettings5;
++using ::ABI::Windows::Media::Capture::MediaCaptureMemoryPreference;
++using ::ABI::Windows::Media::Capture::MediaStreamType;
++using ::ABI::Windows::Media::Capture::StreamingCaptureMode;
++using ::ABI::Windows::Media::Devices::IMediaDeviceController;
++using ::ABI::Windows::Media::Devices::IVideoDeviceController;
++using ::ABI::Windows::Media::MediaProperties::IMediaEncodingProperties;
++using ::ABI::Windows::Media::MediaProperties::IMediaRatio;
++using ::ABI::Windows::Media::MediaProperties::IVideoEncodingProperties;
++using ::ABI::Windows::UI::Core::CoreDispatcherPriority;
++using ::ABI::Windows::UI::Core::CoreProcessEventsOption;
++using ::ABI::Windows::UI::Core::ICoreDispatcher;
++using ::ABI::Windows::UI::Core::ICoreWindow;
++using ::ABI::Windows::UI::Core::IDispatchedHandler;
++using ::Microsoft::WRL::Callback;
++using ::Microsoft::WRL::ComPtr;
++using ::Microsoft::WRL::Delegate;
++using ::Microsoft::WRL::FtmBase;
++using ::Microsoft::WRL::Implements;
++using ::Microsoft::WRL::RuntimeClassFlags;
++using ::Microsoft::WRL::Wrappers::Event;
++using ::Microsoft::WRL::Wrappers::HString;
++using ::Microsoft::WRL::Wrappers::HStringReference;
++using ::Microsoft::WRL::Wrappers::RoInitializeWrapper;
++using ::std::vector;
+ 
+ namespace webrtc {
+ namespace videocapturemodule {
+@@ -68,8 +83,6 @@ struct DeviceInfoWinRTInternal {
+ 
+   ~DeviceInfoWinRTInternal() = default;
+ 
+-  HRESULT Init();
+-
+   HRESULT GetNumberOfDevices(uint32_t* device_count);
+ 
+   HRESULT GetDeviceName(uint32_t device_number,
+@@ -85,71 +98,31 @@ struct DeviceInfoWinRTInternal {
+       vector<VideoCaptureCapability>* video_capture_capabilities);
+ 
+  private:
+-  HRESULT AssureInitialized();
+-
+   HRESULT GetDeviceInformationCollection(
+       IVectorView<DeviceInformation*>** device_collection);
+-
+-  HRESULT AssureDeviceInformation();
+-
+-  RoInitializeWrapper ro_initialize_wrapper_;
+-  ComPtr<IDeviceInformationStatics> device_info_statics_;
+ };
+ 
+-HRESULT DeviceInfoWinRTInternal::AssureDeviceInformation() {
+-  HRESULT hr = S_OK;
+-
+-  if (!device_info_statics_) {
+-    // Get the object containing the DeviceInformation static methods.
+-    THR(GetActivationFactory(
+-        HStringReference(
+-            RuntimeClass_Windows_Devices_Enumeration_DeviceInformation)
+-            .Get(),
+-        &device_info_statics_));
+-  }
+-
+-Cleanup:
+-  return hr;
+-}
+-
+-DeviceInfoWinRTInternal::DeviceInfoWinRTInternal()
+-    : ro_initialize_wrapper_(RO_INIT_MULTITHREADED) {}
+-
+-HRESULT DeviceInfoWinRTInternal::Init() {
+-  HRESULT hr;
+-
+-  THR(AssureInitialized());
+-
+-Cleanup:
+-  return hr;
+-}
+-
+-// Some sample apps don't call DeviceInfoImpl::Init before using the class.
+-// All public methods of this class should assure its initialization.
+-HRESULT DeviceInfoWinRTInternal::AssureInitialized() {
+-  HRESULT hr = S_OK;
+-
+-  // Checks if Windows runtime initialized successfully.
+-  // Pay attention if ro_initialize_wrapper_ is returning RPC_E_CHANGED_MODE.
+-  // It means device_info_winrt is being called from an apartment thread (STA)
+-  // instead of multithreaded (MTA). Usually this means device_info_winrt is
+-  // being called from the UI thread.
+-  THR((HRESULT)ro_initialize_wrapper_);
+-
+-  THR(AssureDeviceInformation());
+-
+-Cleanup:
+-  return hr;
+-}
++DeviceInfoWinRTInternal::DeviceInfoWinRTInternal() {}
+ 
+ HRESULT DeviceInfoWinRTInternal::GetDeviceInformationCollection(
+     IVectorView<DeviceInformation*>** device_collection) {
+   HRESULT hr;
++  ComPtr<IActivationFactory> activation_factory;
++  ComPtr<IDeviceInformationStatics> device_info_statics;
+   ComPtr<IAsyncOperation<DeviceInformationCollection*>>
+       async_op_device_info_collection;
+ 
++  // Get the object containing the DeviceInformation static methods.
++  THR(GetActivationFactory(
++      HStringReference(
++          RuntimeClass_Windows_Devices_Enumeration_DeviceInformation)
++          .Get(),
++      &activation_factory));
++
++  THR(activation_factory.As<IDeviceInformationStatics>(&device_info_statics));
++
+   // Call FindAllAsync and then start the async operation.
+-  THR(device_info_statics_->FindAllAsyncDeviceClass(
++  THR(device_info_statics->FindAllAsyncDeviceClass(
+       DeviceClass_VideoCapture, &async_op_device_info_collection));
+ 
+   // Block and suspend thread until the async operation finishes or timeouts.
+@@ -166,9 +139,6 @@ HRESULT DeviceInfoWinRTInternal::GetNumberOfDevices(uint32_t* device_count) {
+   HRESULT hr;
+   ComPtr<IVectorView<DeviceInformation*>> device_info_collection;
+ 
+-  // Assures class has been properly initialized.
+-  THR(AssureInitialized());
+-
+   THR(GetDeviceInformationCollection(
+       device_info_collection.ReleaseAndGetAddressOf()));
+   THR(device_info_collection->get_Size(device_count));
+@@ -190,9 +160,6 @@ HRESULT DeviceInfoWinRTInternal::GetDeviceName(
+   ComPtr<IVectorView<DeviceInformation*>> device_info_collection;
+   ComPtr<IDeviceInformation> device_info;
+ 
+-  // Assures class has been properly initialized.
+-  THR(AssureInitialized());
+-
+   // Gets the device information collection synchronously
+   THR(GetDeviceInformationCollection(
+       device_info_collection.ReleaseAndGetAddressOf()));
+@@ -281,41 +248,26 @@ HRESULT DeviceInfoWinRTInternal::CreateCapabilityMap(
+     const wchar_t* device_unique_id,
+     vector<VideoCaptureCapability>* video_capture_capabilities) {
+   HRESULT hr;
+-  ComPtr<IMediaCaptureInitializationSettings> init_settings;
+-  ComPtr<IMediaCaptureInitializationSettings5> init_settings5;
++
+   ComPtr<IMediaCapture> media_capture;
+   ComPtr<IClosable> media_capture_closable;
+   ComPtr<IAsyncAction> async_action;
+   ComPtr<IVideoDeviceController> video_device_controller;
+   ComPtr<IMediaDeviceController> media_device_controller;
+   ComPtr<IVectorView<IMediaEncodingProperties*>> stream_capabilities;
++
++  ComPtr<IAsyncAction> async_action_media_capture;
++  Event event_wait_for_media_capture_async_action;
++  Event event_wait_for_media_capture_async_action_complition;
++
+   HStringReference device_id(device_unique_id);
+   unsigned int stream_capabilities_size;
+   vector<VideoCaptureCapability> device_caps;
+ 
+   THR(video_capture_capabilities ? S_OK : E_INVALIDARG);
+ 
+-  // Assures class has been properly initialized.
+-  THR(AssureInitialized());
+-
+-  THR(ActivateInstance(
+-      HStringReference(
+-          RuntimeClass_Windows_Media_Capture_MediaCaptureInitializationSettings)
+-          .Get(),
+-      &init_settings));
+-  THR(init_settings.As<IMediaCaptureInitializationSettings5>(&init_settings5));
+-  THR(init_settings5->put_MemoryPreference(
+-      MediaCaptureMemoryPreference::MediaCaptureMemoryPreference_Cpu));
+-  THR(init_settings->put_VideoDeviceId(device_id.Get()));
+-
+-  THR(ActivateInstance(
+-      HStringReference(RuntimeClass_Windows_Media_Capture_MediaCapture).Get(),
+-      &media_capture));
+-
+-  THR(media_capture->InitializeWithSettingsAsync(init_settings.Get(),
+-                                                 &async_action));
+-
+-  THR(WaitForAsyncAction(async_action));
++  THR(GetMediaCaptureForDevice(device_id.Get(),
++                               media_capture.ReleaseAndGetAddressOf()));
+ 
+   THR(media_capture->get_VideoDeviceController(&video_device_controller));
+   THR(video_device_controller.As<IMediaDeviceController>(
+@@ -389,7 +341,7 @@ DeviceInfoWinRT::~DeviceInfoWinRT() {
+ }
+ 
+ int32_t DeviceInfoWinRT::Init() {
+-  return SUCCEEDED(Impl(device_info_internal_)->Init()) ? 0 : -1;
++  return 0;
+ }
+ 
+ uint32_t DeviceInfoWinRT::NumberOfDevices() {
+diff --git a/modules/video_capture/windows/help_functions_winrt.cc b/modules/video_capture/windows/help_functions_winrt.cc
+index 709c685b26..b3f5de59f2 100644
+--- a/modules/video_capture/windows/help_functions_winrt.cc
++++ b/modules/video_capture/windows/help_functions_winrt.cc
+@@ -10,19 +10,175 @@
+ 
+ #include "modules/video_capture/windows/help_functions_winrt.h"
+ 
+-using ABI::Windows::Foundation::AsyncStatus;
+-using ABI::Windows::Foundation::IAsyncAction;
+-using ABI::Windows::Foundation::IAsyncActionCompletedHandler;
+-using ABI::Windows::Foundation::IAsyncInfo;
+-using ABI::Windows::Media::MediaProperties::IMediaRatio;
+-using Microsoft::WRL::Callback;
+-using Microsoft::WRL::ComPtr;
+-using Microsoft::WRL::Wrappers::Event;
+-using Microsoft::WRL::Wrappers::HString;
++#include <Windows.ApplicationModel.core.h>
++#include <Windows.ApplicationModel.h>
++
++using ::ABI::Windows::ApplicationModel::Core::ICoreApplication;
++using ::ABI::Windows::ApplicationModel::Core::ICoreApplicationView;
++using ::ABI::Windows::ApplicationModel::Core::ICoreImmersiveApplication;
++using ::ABI::Windows::Foundation::ActivateInstance;
++using ::ABI::Windows::Foundation::AsyncStatus;
++using ::ABI::Windows::Foundation::GetActivationFactory;
++using ::ABI::Windows::Foundation::IAsyncAction;
++using ::ABI::Windows::Foundation::IAsyncActionCompletedHandler;
++using ::ABI::Windows::Foundation::IAsyncInfo;
++using ::ABI::Windows::Media::Capture::IMediaCapture;
++using ::ABI::Windows::Media::Capture::IMediaCaptureFailedEventArgs;
++using ::ABI::Windows::Media::Capture::IMediaCaptureFailedEventHandler;
++using ::ABI::Windows::Media::Capture::IMediaCaptureInitializationSettings;
++using ::ABI::Windows::Media::Capture::IMediaCaptureInitializationSettings5;
++using ::ABI::Windows::Media::Capture::MediaCaptureMemoryPreference;
++using ::ABI::Windows::Media::Capture::StreamingCaptureMode;
++using ::ABI::Windows::Media::MediaProperties::IMediaRatio;
++using ::ABI::Windows::UI::Core::CoreDispatcherPriority;
++using ::ABI::Windows::UI::Core::CoreProcessEventsOption;
++using ::ABI::Windows::UI::Core::ICoreDispatcher;
++using ::ABI::Windows::UI::Core::ICoreWindow;
++using ::ABI::Windows::UI::Core::IDispatchedHandler;
++using ::Microsoft::WRL::AgileRef;
++using ::Microsoft::WRL::Callback;
++using ::Microsoft::WRL::ComPtr;
++using ::Microsoft::WRL::Delegate;
++using ::Microsoft::WRL::FtmBase;
++using ::Microsoft::WRL::Implements;
++using ::Microsoft::WRL::RuntimeClassFlags;
++using ::Microsoft::WRL::Wrappers::Event;
++using ::Microsoft::WRL::Wrappers::HString;
++using ::Microsoft::WRL::Wrappers::HStringReference;
+ 
+ namespace webrtc {
+ namespace videocapturemodule {
+ 
++HRESULT GetMediaCaptureForDevice(HSTRING device_id,
++                                  IMediaCapture** ppMediaCapture) {
++  HRESULT hr;
++
++  ComPtr<ICoreDispatcher> main_view_dispatcher;
++  ComPtr<IAsyncAction> async_action_ui_dispatcher;
++  ComPtr<IAsyncAction> async_action_media_capture;
++  ComPtr<IMediaCapture> media_capture;
++  AgileRef media_capture_agile;
++  AgileRef async_action_media_capture_agile;
++  Event event_wait_for_media_capture_async_action;
++  Event event_wait_for_media_capture_async_action_completion;
++  boolean has_thread_access;
++
++  // Acquires the main view dispacther (UI thread).
++  THR(GetMainViewDispatcher(&main_view_dispatcher));
++
++  // We'll be dispatching and waiting for code from the UI thread.
++  // Let's make sure this is not the UI thread.
++  THR(main_view_dispatcher->get_HasThreadAccess(&has_thread_access));
++  THR(has_thread_access ? E_FAIL : S_OK);
++
++  // The media capture device has to be initialized in the UI thread.
++  // The following event is used for letting this thread know that
++  // async_action_media_capture has been created.
++  event_wait_for_media_capture_async_action =
++      Event(::CreateEventEx(nullptr, nullptr, CREATE_EVENT_MANUAL_RESET,
++                            WRITE_OWNER | EVENT_ALL_ACCESS));
++  THR(event_wait_for_media_capture_async_action.IsValid()
++          ? S_OK
++          : HRESULT_FROM_WIN32(GetLastError()));
++
++  THR(ActivateInstance(
++      HStringReference(RuntimeClass_Windows_Media_Capture_MediaCapture).Get(),
++      media_capture.ReleaseAndGetAddressOf()));
++
++  THR(media_capture.AsAgile(&media_capture_agile));
++
++  // Dispatches the media capture initialization to the main view
++  // dispatcher.
++  THR(main_view_dispatcher->RunAsync(
++      CoreDispatcherPriority::CoreDispatcherPriority_Normal,
++      Callback<Implements<RuntimeClassFlags<Delegate>, IDispatchedHandler,
++                          FtmBase>>([&event_wait_for_media_capture_async_action,
++                                     &async_action_media_capture_agile,
++                                     &media_capture_agile,
++                                     &device_id]() -> HRESULT {
++        HRESULT hr;
++
++        ComPtr<IMediaCapture> media_capture;
++        ComPtr<IAsyncAction> media_capture_async;
++        ComPtr<IMediaCaptureInitializationSettings> init_settings;
++        ComPtr<IMediaCaptureInitializationSettings5> init_settings5;
++
++        THR(media_capture_agile.As(&media_capture));
++
++        // Creates the settings used to select which capture device will be
++        // used.
++        THR(ActivateInstance(
++            HStringReference(
++                RuntimeClass_Windows_Media_Capture_MediaCaptureInitializationSettings)
++                .Get(),
++            &init_settings));
++        THR(init_settings->put_StreamingCaptureMode(
++            StreamingCaptureMode::StreamingCaptureMode_AudioAndVideo));
++        THR(init_settings.As<IMediaCaptureInitializationSettings5>(
++            &init_settings5));
++        THR(init_settings5->put_MemoryPreference(
++            MediaCaptureMemoryPreference::MediaCaptureMemoryPreference_Cpu));
++        THR(init_settings->put_VideoDeviceId(device_id));
++
++        THR(media_capture->InitializeWithSettingsAsync(init_settings.Get(),
++                                                       &media_capture_async));
++
++        THR(media_capture_async.AsAgile(&async_action_media_capture_agile));
++
++      Cleanup:
++        ::SetEvent(event_wait_for_media_capture_async_action.Get());
++        return hr;
++      }).Get(),
++      &async_action_ui_dispatcher));
++
++  // Waits for the UI thread to create async_action_media_capture.
++  THR(::WaitForSingleObjectEx(event_wait_for_media_capture_async_action.Get(),
++                              INFINITE, FALSE) == WAIT_OBJECT_0
++          ? S_OK
++          : E_FAIL);
++
++  // Waits for user to approve (or not) access to the microphone and
++  // camera.
++  event_wait_for_media_capture_async_action_completion =
++      Event(::CreateEventEx(nullptr, nullptr, CREATE_EVENT_MANUAL_RESET,
++                            WRITE_OWNER | EVENT_ALL_ACCESS));
++  THR(event_wait_for_media_capture_async_action_completion.IsValid()
++          ? S_OK
++          : HRESULT_FROM_WIN32(GetLastError()));
++
++  // Waits until user grant (or deny) access to the camera.
++  THR(async_action_media_capture_agile.As(&async_action_media_capture));
++  THR(async_action_media_capture->put_Completed(
++      Callback<IAsyncActionCompletedHandler>(
++          [&event_wait_for_media_capture_async_action_completion](
++              IAsyncAction*, AsyncStatus async_status) -> HRESULT {
++            HRESULT hr;
++
++            // Checks if user granted permission to access the camera.
++            THR(async_status == AsyncStatus::Completed ? S_OK : E_ACCESSDENIED);
++
++          Cleanup:
++            ::SetEvent(
++                event_wait_for_media_capture_async_action_completion.Get());
++
++            return hr;
++          })
++          .Get()));
++
++  THR(::WaitForSingleObjectEx(
++          event_wait_for_media_capture_async_action_completion.Get(), INFINITE,
++          FALSE) == WAIT_OBJECT_0
++          ? S_OK
++          : E_FAIL);
++
++  // User granted access, good to go.
++  ReleaseInterface(ppMediaCapture);
++  *ppMediaCapture = media_capture.Detach();
++
++Cleanup:
++  return hr;
++}
++
+ uint32_t SafelyComputeMediaRatio(IMediaRatio* ratio_no_ref) {
+   HRESULT hr;
+   uint32_t numerator, denominator, media_ratio = 0;
+@@ -70,6 +226,31 @@ VideoType ToVideoType(const HString& sub_type) {
+   return converted_type;
+ }
+ 
++HRESULT GetMainViewDispatcher(ICoreDispatcher** main_view_dispatcher) {
++  HRESULT hr;
++
++  ComPtr<IActivationFactory> activation_factory;
++  ComPtr<ICoreApplication> coreApplication;
++  ComPtr<ICoreImmersiveApplication> immersiveApplication;
++  ComPtr<ICoreApplicationView> applicationView;
++  ComPtr<ICoreWindow> coreWindow;
++
++  THR(GetActivationFactory(
++      HStringReference(
++          RuntimeClass_Windows_ApplicationModel_Core_CoreApplication)
++          .Get(),
++      &activation_factory));
++
++  THR(activation_factory.As<ICoreApplication>(&coreApplication));
++  THR(coreApplication.As<ICoreImmersiveApplication>(&immersiveApplication));
++  THR(immersiveApplication->get_MainView(&applicationView));
++  THR(applicationView->get_CoreWindow(&coreWindow));
++  THR(coreWindow->get_Dispatcher(main_view_dispatcher));
++
++Cleanup:
++  return hr;
++}
++
+ HRESULT WaitForAsyncAction(ComPtr<IAsyncAction> async_action) {
+   HRESULT hr, hr_async_error;
+   const DWORD timeout_ms = 2000;
+diff --git a/modules/video_capture/windows/help_functions_winrt.h b/modules/video_capture/windows/help_functions_winrt.h
+index 0216d9b0ce..6b81bfc977 100644
+--- a/modules/video_capture/windows/help_functions_winrt.h
++++ b/modules/video_capture/windows/help_functions_winrt.h
+@@ -13,6 +13,7 @@
+ 
+ #include <windows.foundation.h>
+ #include <windows.media.mediaproperties.h>
++#include <windows.ui.core.h>
+ #include <wrl/client.h>
+ #include <wrl/event.h>
+ #include <wrl/wrappers/corewrappers.h>
+@@ -20,15 +21,51 @@
+ #include <cassert>
+ 
+ #include "modules/video_capture/video_capture_defines.h"
++#include "rtc_base/logging.h"
+ 
+ // Evaluates an expression returning a HRESULT.
+ // It jumps to a label named Cleanup on failure.
+-#define THR(expr)   \
+-  do {              \
+-    hr = (expr);    \
+-    if (FAILED(hr)) \
+-      goto Cleanup; \
++#ifdef _DEBUG
++#define THR(expr)                                           \
++  do {                                                      \
++    hr = (expr);                                            \
++    if (FAILED(hr)) {                                       \
++      RTC_LOG(LS_ERROR) << "HR: " << hr;                    \
++      RTC_LOG(LS_ERROR) << __FUNCTION__ << ":" << __LINE__; \
++      __debugbreak();                                       \
++      goto Cleanup;                                         \
++    }                                                       \
+   } while (false)
++#else
++#define THR(expr)     \
++  do {                \
++    hr = (expr);      \
++    if (FAILED(hr)) { \
++      goto Cleanup;   \
++    }                 \
++  } while (false)
++#endif
++
++template <typename T>
++void ReleaseInterface(T** ppInterface) {
++  if ((*ppInterface)) {
++    (*ppInterface)->Release();
++    (*ppInterface) = nullptr;
++  }
++}
++
++template <typename T, typename U>
++void ReplaceInterface(T** ppInterface, U* pSource) {
++  if ((*ppInterface)) {
++    (*ppInterface)->Release();
++  }
++
++  (*ppInterface) = pSource;
++
++  if (pSource) {
++    pSource->AddRef();
++  }
++}
+ 
+ namespace webrtc {
+ namespace videocapturemodule {
+@@ -38,6 +75,13 @@ uint32_t SafelyComputeMediaRatio(
+ 
+ VideoType ToVideoType(const Microsoft::WRL::Wrappers::HString& sub_type);
+ 
++HRESULT GetMainViewDispatcher(
++    ::ABI::Windows::UI::Core::ICoreDispatcher** dispatcher);
++
++HRESULT GetMediaCaptureForDevice(
++    HSTRING device_id,
++    ::ABI::Windows::Media::Capture::IMediaCapture** pp_media_capture);
++
+ HRESULT WaitForAsyncAction(
+     Microsoft::WRL::ComPtr<ABI::Windows::Foundation::IAsyncAction>
+         async_action);
+diff --git a/modules/video_capture/windows/video_capture_winrt.cc b/modules/video_capture/windows/video_capture_winrt.cc
+index 5aa3541b34..5cc6154837 100644
+--- a/modules/video_capture/windows/video_capture_winrt.cc
++++ b/modules/video_capture/windows/video_capture_winrt.cc
+@@ -141,9 +141,6 @@ Cleanup:
+ 
+ HRESULT VideoCaptureWinRTInternal::InitCamera(const wchar_t* device_unique_id) {
+   HRESULT hr;
+-  ComPtr<IMediaCaptureInitializationSettings> settings;
+-  ComPtr<IMediaCaptureInitializationSettings5> settings5;
+-  ComPtr<IAsyncAction> async_action;
+   HStringReference device_id(device_unique_id);
+ 
+   if (media_capture_) {
+@@ -153,24 +150,9 @@ HRESULT VideoCaptureWinRTInternal::InitCamera(const wchar_t* device_unique_id) {
+     THR(StopCapture() == 0 ? S_OK : E_FAIL);
+     THR(closable_media_capture->Close());
+   }
+-  THR(ActivateInstance(
+-      HStringReference(RuntimeClass_Windows_Media_Capture_MediaCapture).Get(),
+-      media_capture_.ReleaseAndGetAddressOf()));
+-
+-  // Defines the settings to be used the camera
+-  THR(ActivateInstance(
+-      HStringReference(
+-          RuntimeClass_Windows_Media_Capture_MediaCaptureInitializationSettings)
+-          .Get(),
+-      &settings));
+-  THR(settings.As(&settings5));
+-  THR(settings5->put_MemoryPreference(
+-      MediaCaptureMemoryPreference::MediaCaptureMemoryPreference_Cpu));
+-  THR(settings->put_VideoDeviceId(device_id.Get()));
+ 
+-  THR(media_capture_->InitializeWithSettingsAsync(settings.Get(),
+-                                                  &async_action));
+-  THR(WaitForAsyncAction(async_action));
++  THR(GetMediaCaptureForDevice(device_id.Get(),
++                                media_capture_.ReleaseAndGetAddressOf()));
+ 
+ Cleanup:
+   return hr;
+@@ -183,7 +165,8 @@ HRESULT VideoCaptureWinRTInternal::StartCapture(
+   ComPtr<IMediaCapture5> media_capture5;
+   ComPtr<IMapView<HSTRING, MediaFrameSource*>> frame_sources;
+   ComPtr<IIterable<IKeyValuePair<HSTRING, MediaFrameSource*>*>> iterable;
+-  ComPtr<IIterator<IKeyValuePair<HSTRING, MediaFrameSource*>*>> frame_source_iterator;
++  ComPtr<IIterator<IKeyValuePair<HSTRING, MediaFrameSource*>*>>
++      frame_source_iterator;
+   ComPtr<IAsyncOperation<MediaFrameReader*>> async_operation;
+   ComPtr<IAsyncOperation<MediaFrameReaderStartStatus>>
+       async_media_frame_reader_start_status;
+-- 
+2.21.0.windows.1
+

--- a/patches_for_WebRTC_org/m80/0007.2-Properly-handling-async-model-for-initializing-Media.patch
+++ b/patches_for_WebRTC_org/m80/0007.2-Properly-handling-async-model-for-initializing-Media.patch
@@ -1,4 +1,4 @@
-From 8169d726cdc4ef049d6ef64e202e07e3bb58ee3b Mon Sep 17 00:00:00 2001
+From ee2a99a20bd6d53f0314a0303cff730391494ff9 Mon Sep 17 00:00:00 2001
 From: Augusto Righetto <aurighet@microsoft.com>
 Date: Wed, 27 May 2020 23:38:26 -0700
 Subject: [PATCH] Properly handling async model for initializing MediaCapture
@@ -8,9 +8,9 @@ Working around the stride and gap issues with NV12 memory layout
 ---
  .../windows/device_info_winrt.cc              | 178 ++++++----------
  .../windows/help_functions_winrt.cc           | 199 +++++++++++++++++-
- .../windows/help_functions_winrt.h            |  54 ++++-
+ .../windows/help_functions_winrt.h            |  53 ++++-
  .../windows/video_capture_winrt.cc            |  61 ++++--
- 4 files changed, 343 insertions(+), 149 deletions(-)
+ 4 files changed, 342 insertions(+), 149 deletions(-)
 
 diff --git a/modules/video_capture/windows/device_info_winrt.cc b/modules/video_capture/windows/device_info_winrt.cc
 index 3b2a7aa773..2a7676be1a 100644
@@ -268,7 +268,7 @@ index 3b2a7aa773..2a7676be1a 100644
  
  uint32_t DeviceInfoWinRT::NumberOfDevices() {
 diff --git a/modules/video_capture/windows/help_functions_winrt.cc b/modules/video_capture/windows/help_functions_winrt.cc
-index 709c685b26..b3f5de59f2 100644
+index 709c685b26..83f599fb6f 100644
 --- a/modules/video_capture/windows/help_functions_winrt.cc
 +++ b/modules/video_capture/windows/help_functions_winrt.cc
 @@ -10,19 +10,175 @@
@@ -343,7 +343,7 @@ index 709c685b26..b3f5de59f2 100644
 +  // We'll be dispatching and waiting for code from the UI thread.
 +  // Let's make sure this is not the UI thread.
 +  THR(main_view_dispatcher->get_HasThreadAccess(&has_thread_access));
-+  THR(has_thread_access ? E_FAIL : S_OK);
++  THR(has_thread_access ? RPC_E_WRONG_THREAD : S_OK);
 +
 +  // The media capture device has to be initialized in the UI thread.
 +  // The following event is used for letting this thread know that
@@ -489,7 +489,7 @@ index 709c685b26..b3f5de59f2 100644
    HRESULT hr, hr_async_error;
    const DWORD timeout_ms = 2000;
 diff --git a/modules/video_capture/windows/help_functions_winrt.h b/modules/video_capture/windows/help_functions_winrt.h
-index 0216d9b0ce..6b81bfc977 100644
+index 0216d9b0ce..7c55f87654 100644
 --- a/modules/video_capture/windows/help_functions_winrt.h
 +++ b/modules/video_capture/windows/help_functions_winrt.h
 @@ -13,6 +13,7 @@
@@ -500,7 +500,7 @@ index 0216d9b0ce..6b81bfc977 100644
  #include <wrl/client.h>
  #include <wrl/event.h>
  #include <wrl/wrappers/corewrappers.h>
-@@ -20,15 +21,51 @@
+@@ -20,15 +21,50 @@
  #include <cassert>
  
  #include "modules/video_capture/video_capture_defines.h"
@@ -518,8 +518,7 @@ index 0216d9b0ce..6b81bfc977 100644
 +  do {                                                      \
 +    hr = (expr);                                            \
 +    if (FAILED(hr)) {                                       \
-+      RTC_LOG(LS_ERROR) << "HR: " << hr;                    \
-+      RTC_LOG(LS_ERROR) << __FUNCTION__ << ":" << __LINE__; \
++      RTC_LOG_F(LS_ERROR) << "HR: " << hr;                  \
 +      __debugbreak();                                       \
 +      goto Cleanup;                                         \
 +    }                                                       \
@@ -557,7 +556,7 @@ index 0216d9b0ce..6b81bfc977 100644
  
  namespace webrtc {
  namespace videocapturemodule {
-@@ -38,6 +75,13 @@ uint32_t SafelyComputeMediaRatio(
+@@ -38,6 +74,13 @@ uint32_t SafelyComputeMediaRatio(
  
  VideoType ToVideoType(const Microsoft::WRL::Wrappers::HString& sub_type);
  
@@ -572,7 +571,7 @@ index 0216d9b0ce..6b81bfc977 100644
      Microsoft::WRL::ComPtr<ABI::Windows::Foundation::IAsyncAction>
          async_action);
 diff --git a/modules/video_capture/windows/video_capture_winrt.cc b/modules/video_capture/windows/video_capture_winrt.cc
-index 5aa3541b34..4a8a597bdf 100644
+index 5aa3541b34..44d7cdca68 100644
 --- a/modules/video_capture/windows/video_capture_winrt.cc
 +++ b/modules/video_capture/windows/video_capture_winrt.cc
 @@ -68,6 +68,7 @@ using ABI::Windows::Media::Capture::Frames::MediaFrameReaderStartStatus;
@@ -663,12 +662,12 @@ index 5aa3541b34..4a8a597bdf 100644
                                               &bitmap_capacity));
  
 -    pfn_incoming_frame_(bitmap_content, bitmap_capacity, frameInfo, 0);
-+    // hack(auright): The following hack works around the limitations of 
++    // workaround(auright): The following code works around the limitations of 
 +    // libWebRTC memory representations for YUV planar images. Windows::Media::Capture allows
 +    // representing NV12 images with strides greater than YUV widths and with a gap between
 +    // the Y plane and the UV planes. The following workaround compresses the image in memory
 +    // by removing the gap between planes and making the stride equal to widths. This is a
-+    // temporary hack until the implementation with Media Foundation is in place.
++    // temporary workaround until the implementation with Media Foundation is in place.
 +    if ((bitmap_plane_description_y.Width != bitmap_plane_description_y.Stride) ||
 +        (bitmap_plane_description_uv.Width * 2 != bitmap_plane_description_uv.Stride) ||
 +        (bitmap_plane_description_y.Width * bitmap_plane_description_y.Height != bitmap_plane_description_uv.StartIndex)) {

--- a/patches_for_WebRTC_org/m80/0007.3-Fixing-NV12-to-I420-conversion-with-strides-and-gap.patch
+++ b/patches_for_WebRTC_org/m80/0007.3-Fixing-NV12-to-I420-conversion-with-strides-and-gap.patch
@@ -1,0 +1,76 @@
+From 144df9fb8e4dbc56130b276291ee0d8513313c81 Mon Sep 17 00:00:00 2001
+From: Augusto Righetto <aurighet@microsoft.com>
+Date: Tue, 9 Jun 2020 08:59:05 -0700
+Subject: [PATCH] Fixing NV12 to I420 conversion with strides and gap
+
+---
+ include/libyuv/convert.h  |  3 +++
+ source/convert_to_i420.cc | 19 ++++++++++---------
+ 2 files changed, 13 insertions(+), 9 deletions(-)
+
+diff --git a/include/libyuv/convert.h b/include/libyuv/convert.h
+index f571142f..b4534f14 100644
+--- a/include/libyuv/convert.h
++++ b/include/libyuv/convert.h
+@@ -481,6 +481,9 @@ int MJPGSize(const uint8_t* sample,
+ LIBYUV_API
+ int ConvertToI420(const uint8_t* sample,
+                   size_t sample_size,
++                  int src_stride_y,
++                  const uint8_t* src_uv,
++                  int src_stride_uv,
+                   uint8_t* dst_y,
+                   int dst_stride_y,
+                   uint8_t* dst_u,
+diff --git a/source/convert_to_i420.cc b/source/convert_to_i420.cc
+index 584be0ac..a95aabed 100644
+--- a/source/convert_to_i420.cc
++++ b/source/convert_to_i420.cc
+@@ -27,6 +27,9 @@ extern "C" {
+ LIBYUV_API
+ int ConvertToI420(const uint8_t* sample,
+                   size_t sample_size,
++                  int src_stride_y,
++                  const uint8_t* src_uv,
++                  int src_stride_uv,
+                   uint8_t* dst_y,
+                   int dst_stride_y,
+                   uint8_t* dst_u,
+@@ -44,7 +47,7 @@ int ConvertToI420(const uint8_t* sample,
+   uint32_t format = CanonicalFourCC(fourcc);
+   int aligned_src_width = (src_width + 1) & ~1;
+   const uint8_t* src;
+-  const uint8_t* src_uv;
++  const uint8_t* src_uv_cropped;
+   const int abs_src_height = (src_height < 0) ? -src_height : src_height;
+   // TODO(nisse): Why allow crop_height < 0?
+   const int abs_crop_height = (crop_height < 0) ? -crop_height : crop_height;
+@@ -163,19 +166,17 @@ int ConvertToI420(const uint8_t* sample,
+       break;
+     // Biplanar formats
+     case FOURCC_NV12:
+-      src = sample + (src_width * crop_y + crop_x);
+-      src_uv = sample + (src_width * abs_src_height) +
+-               ((crop_y / 2) * aligned_src_width) + ((crop_x / 2) * 2);
+-      r = NV12ToI420Rotate(src, src_width, src_uv, aligned_src_width, dst_y,
++      src = sample + (src_stride_y * crop_y + crop_x);
++      src_uv_cropped = src_uv + ((crop_y / 2) * src_stride_uv) + ((crop_x / 2) * 2);
++      r = NV12ToI420Rotate(src, src_stride_y, src_uv_cropped, src_stride_uv, dst_y,
+                            dst_stride_y, dst_u, dst_stride_u, dst_v,
+                            dst_stride_v, crop_width, inv_crop_height, rotation);
+       break;
+     case FOURCC_NV21:
+-      src = sample + (src_width * crop_y + crop_x);
+-      src_uv = sample + (src_width * abs_src_height) +
+-               ((crop_y / 2) * aligned_src_width) + ((crop_x / 2) * 2);
++      src = sample + (src_stride_y * crop_y + crop_x);
++      src_uv_cropped = src_uv + ((crop_y / 2) * src_stride_uv) + ((crop_x / 2) * 2);
+       // Call NV12 but with dst_u and dst_v parameters swapped.
+-      r = NV12ToI420Rotate(src, src_width, src_uv, aligned_src_width, dst_y,
++      r = NV12ToI420Rotate(src, src_stride_y, src_uv_cropped, src_stride_uv, dst_y,
+                            dst_stride_y, dst_v, dst_stride_v, dst_u,
+                            dst_stride_u, crop_width, inv_crop_height, rotation);
+       break;
+-- 
+2.21.0.windows.1
+

--- a/patches_for_WebRTC_org/m80/patchWebRTCM80.cmd
+++ b/patches_for_WebRTC_org/m80/patchWebRTCM80.cmd
@@ -14,6 +14,10 @@ git.exe am "%PATCH_DIR%0002-UWP-apps-do-support-GetProcAddress-but-do-support-Ge
 git.exe am "%PATCH_DIR%0009-Fixing-UWP-build-for-libvpx.patch"
 popd
 
+pushd %WEBRTCM80_ROOT%\third_party\libyuv
+git.exe am "%PATCH_DIR%0007.3-Fixing-NV12-to-I420-conversion-with-strides-and-gap.patch"
+popd
+
 pushd %WEBRTCM80_ROOT%\third_party\boringssl\src
 git.exe am "%PATCH_DIR%0003-Replacing-deprecated-and-non-UWP-supported-RtlGenRan.patch"
 git.exe am "%PATCH_DIR%6401-Arm64-is-a-thing-and-has-intrinsic-to-mul-two-64bit-.patch"

--- a/patches_for_WebRTC_org/m80/patchWebRTCM80.cmd
+++ b/patches_for_WebRTC_org/m80/patchWebRTCM80.cmd
@@ -29,6 +29,7 @@ git.exe am "%PATCH_DIR%0005-Fixing-UWP-build-for-time_utils.cc.patch"
 git.exe am "%PATCH_DIR%0006-Fixing-UWP-build-for-file_rotating_stream.cc.patch"
 git.exe am "%PATCH_DIR%0007-Fixing-UWP-build-for-modules-video_capture.patch"
 git.exe am "%PATCH_DIR%0007.1-BUG-Requested-camera-settings-were-not-being-honored.patch"
+git.exe am "%PATCH_DIR%0007.2-Properly-handling-async-model-for-initializing-Media.patch"
 git.exe am "%PATCH_DIR%0008-Fixing-UWP-build-for-modules-audio_device.patch"
 git.exe am "%PATCH_DIR%6401-Shift-operator-in-Arm-doesn-t-work-the-same-as-Intel.patch"
 popd


### PR DESCRIPTION
The documentation states that in apps that use C# or C++, the first use of the MediaCapture object to call InitializeAsync family methods should be on the STA thread. Calls from an MTA thread may result in undefined behavior.

It seems that, in UWP, calling MediaCapture::InitializeAsync from a MTA thread works, but calling MediaCapture::InitializeWithSettingsAsync from a MTA thread doesn’t work properly. This restriction seems to not repro in Win32.

This change transfers the MediaCapture initialization call to the STA thread (UI thread). Additionally, this change handles correctly the async pattern used for requesting camera and microphone permissions from the user.