### PR TITLE
Porting H264 encoder from the WebRTC-UWP project

### DIFF
--- a/patches_for_WebRTC_org/m80/0007.5-Porting-H264-encoder-from-the-WebRTC-UWP-project.patch
+++ b/patches_for_WebRTC_org/m80/0007.5-Porting-H264-encoder-from-the-WebRTC-UWP-project.patch
@@ -1,0 +1,3098 @@
+From 1ee669bfd3c3825eed82280eb1e998f4f4db5ebd Mon Sep 17 00:00:00 2001
+From: Augusto Righetto <aurighet@microsoft.com>
+Date: Mon, 15 Jun 2020 17:27:38 -0700
+Subject: [PATCH] Porting H264 encoder from the WebRTC-UWP project
+
+This change ports the H264 encoders from the WebRTC-UWP project. The following are a list of changes made while porting the code:
+. Manually resetting the sink writer to stop generating key frames. Previously, the ::Encode method was adding an attribute to the sink writer for generating a key frame. The flag for generating key frames was not being restored to stop generating key frames. Documentation states that CODECAPI_AVEncVideoForceKeyFrame should reset to zero after the next frame, but visual results are apparently better after manually resetting to zero.
+. All ComPtrs explicitly call ReleaseAndGetAddressOf instead of operator& to clarify intent.
+. Files renamed to follow WebRTC naming convention.
+. Factory has been updated to use the new interface.
+. Encoder's unused data members have been removed.
+. Linker is not instructed to add MF libraries via pragma comment any longer.
+. Adding a build flag for enabling the MF based H264 encoder.
+---
+ BUILD.gn                                      |   4 +
+ media/engine/internal_encoder_factory.cc      |   2 +-
+ modules/video_coding/BUILD.gn                 |  41 +-
+ modules/video_coding/codecs/h264/h264.cc      |  21 +-
+ .../codecs/h264/h264_decoder_mf_impl.cc       | 575 +++++++++++++++++
+ .../codecs/h264/h264_decoder_mf_impl.h        |  85 +++
+ .../h264/win/encoder/h264_encoder_mf_impl.cc  | 551 ++++++++++++++++
+ .../h264/win/encoder/h264_encoder_mf_impl.h   |  96 +++
+ .../h264/win/encoder/h264_media_sink.cc       | 281 ++++++++
+ .../codecs/h264/win/encoder/h264_media_sink.h | 102 +++
+ .../h264/win/encoder/h264_stream_sink.cc      | 605 ++++++++++++++++++
+ .../h264/win/encoder/h264_stream_sink.h       | 170 +++++
+ .../win/encoder/ih264_encoding_callback.h     |  26 +
+ .../codecs/h264/win/h264_mf_factory.cc        |  62 ++
+ .../codecs/h264/win/h264_mf_factory.h         |  35 +
+ .../codecs/h264/win/utils/async.h             |  66 ++
+ .../codecs/h264/win/utils/crit_sec.h          |  57 ++
+ .../h264/win/utils/sample_attribute_queue.h   |  69 ++
+ .../codecs/h264/win/utils/utils.h             |  33 +
+ webrtc.gni                                    |   4 +
+ 20 files changed, 2869 insertions(+), 16 deletions(-)
+ create mode 100644 modules/video_coding/codecs/h264/h264_decoder_mf_impl.cc
+ create mode 100644 modules/video_coding/codecs/h264/h264_decoder_mf_impl.h
+ create mode 100644 modules/video_coding/codecs/h264/win/encoder/h264_encoder_mf_impl.cc
+ create mode 100644 modules/video_coding/codecs/h264/win/encoder/h264_encoder_mf_impl.h
+ create mode 100644 modules/video_coding/codecs/h264/win/encoder/h264_media_sink.cc
+ create mode 100644 modules/video_coding/codecs/h264/win/encoder/h264_media_sink.h
+ create mode 100644 modules/video_coding/codecs/h264/win/encoder/h264_stream_sink.cc
+ create mode 100644 modules/video_coding/codecs/h264/win/encoder/h264_stream_sink.h
+ create mode 100644 modules/video_coding/codecs/h264/win/encoder/ih264_encoding_callback.h
+ create mode 100644 modules/video_coding/codecs/h264/win/h264_mf_factory.cc
+ create mode 100644 modules/video_coding/codecs/h264/win/h264_mf_factory.h
+ create mode 100644 modules/video_coding/codecs/h264/win/utils/async.h
+ create mode 100644 modules/video_coding/codecs/h264/win/utils/crit_sec.h
+ create mode 100644 modules/video_coding/codecs/h264/win/utils/sample_attribute_queue.h
+ create mode 100644 modules/video_coding/codecs/h264/win/utils/utils.h
+
+diff --git a/BUILD.gn b/BUILD.gn
+index f4988035b9..1aea0e018a 100644
+--- a/BUILD.gn
++++ b/BUILD.gn
+@@ -263,6 +263,10 @@ config("common_config") {
+     defines += [ "WEBRTC_USE_H264" ]
+   }
+ 
++  if (rtc_win_use_mf_h264) {
++    defines += [ "WEBRTC_WIN_USE_MF_H264" ]
++  }
++
+   if (rtc_disable_logging) {
+     defines += [ "RTC_DISABLE_LOGGING" ]
+   }
+diff --git a/media/engine/internal_encoder_factory.cc b/media/engine/internal_encoder_factory.cc
+index 331f22b794..902a1fe9db 100644
+--- a/media/engine/internal_encoder_factory.cc
++++ b/media/engine/internal_encoder_factory.cc
+@@ -37,7 +37,7 @@ std::vector<SdpVideoFormat> InternalEncoderFactory::GetSupportedFormats()
+ VideoEncoderFactory::CodecInfo InternalEncoderFactory::QueryVideoEncoder(
+     const SdpVideoFormat& format) const {
+   CodecInfo info;
+-  info.is_hardware_accelerated = false;
++  info.is_hardware_accelerated = true;
+   info.has_internal_source = false;
+   return info;
+ }
+diff --git a/modules/video_coding/BUILD.gn b/modules/video_coding/BUILD.gn
+index ceee019e06..64d47e3a6b 100644
+--- a/modules/video_coding/BUILD.gn
++++ b/modules/video_coding/BUILD.gn
+@@ -314,15 +314,44 @@ rtc_library("webrtc_h264") {
+   visibility = [ "*" ]
+   sources = [
+     "codecs/h264/h264.cc",
+-    "codecs/h264/h264_color_space.cc",
+-    "codecs/h264/h264_color_space.h",
+-    "codecs/h264/h264_decoder_impl.cc",
+-    "codecs/h264/h264_decoder_impl.h",
+-    "codecs/h264/h264_encoder_impl.cc",
+-    "codecs/h264/h264_encoder_impl.h",
+     "codecs/h264/include/h264.h",
+   ]
+ 
++  if (rtc_use_h264) {
++    sources += [
++      "codecs/h264/h264_color_space.cc",
++      "codecs/h264/h264_color_space.h",
++      "codecs/h264/h264_decoder_impl.cc",
++      "codecs/h264/h264_decoder_impl.h",
++      "codecs/h264/h264_encoder_impl.cc",
++      "codecs/h264/h264_encoder_impl.h",
++     ]
++  }
++
++  if (rtc_win_use_mf_h264) {
++    sources += [
++      "codecs/h264/win/h264_mf_factory.cc",
++      "codecs/h264/win/h264_mf_factory.h",
++      "codecs/h264/win/utils/async.h",
++      "codecs/h264/win/utils/crit_sec.h",
++      "codecs/h264/win/utils/utils.h",
++      "codecs/h264/win/utils/sample_attribute_queue.h",
++      "codecs/h264/win/encoder/h264_encoder_mf_impl.cc",
++      "codecs/h264/win/encoder/h264_encoder_mf_impl.h",
++      "codecs/h264/win/encoder/h264_media_sink.cc",
++      "codecs/h264/win/encoder/h264_media_sink.h",
++      "codecs/h264/win/encoder/h264_stream_sink.cc",
++      "codecs/h264/win/encoder/h264_stream_sink.h",
++      "codecs/h264/win/encoder/ih264_encoding_callback.h",
++    ]
++
++    libs = [
++      "mfreadwrite",
++      "mfplat",
++      "mfuuid",
++    ]
++  }
++
+   defines = []
+   deps = [
+     ":video_codec_interface",
+diff --git a/modules/video_coding/codecs/h264/h264.cc b/modules/video_coding/codecs/h264/h264.cc
+index 147e964b54..b8e9aa1984 100644
+--- a/modules/video_coding/codecs/h264/h264.cc
++++ b/modules/video_coding/codecs/h264/h264.cc
+@@ -68,26 +68,29 @@ void DisableRtcUseH264() {
+ std::vector<SdpVideoFormat> SupportedH264Codecs() {
+   if (!IsH264CodecSupported())
+     return std::vector<SdpVideoFormat>();
+-  // We only support encoding Constrained Baseline Profile (CBP), but the
+-  // decoder supports more profiles. We can list all profiles here that are
+-  // supported by the decoder and that are also supersets of CBP, i.e. the
+-  // decoder for that profile is required to be able to decode CBP. This means
+-  // we can encode and send CBP even though we negotiated a potentially
+-  // higher profile. See the H264 spec for more information.
+-  //
+-  // We support both packetization modes 0 (mandatory) and 1 (optional,
+-  // preferred).
++    // We only support encoding Constrained Baseline Profile (CBP), but the
++    // decoder supports more profiles. We can list all profiles here that are
++    // supported by the decoder and that are also supersets of CBP, i.e. the
++    // decoder for that profile is required to be able to decode CBP. This means
++    // we can encode and send CBP even though we negotiated a potentially
++    // higher profile. See the H264 spec for more information.
++    //
++    // We support both packetization modes 0 (mandatory) and 1 (optional,
++    // preferred).
++#if defined(WEBRTC_USE_H264)
+   return {
+       CreateH264Format(H264::kProfileBaseline, H264::kLevel3_1, "1"),
+       CreateH264Format(H264::kProfileBaseline, H264::kLevel3_1, "0"),
+       CreateH264Format(H264::kProfileConstrainedBaseline, H264::kLevel3_1, "1"),
+       CreateH264Format(H264::kProfileConstrainedBaseline, H264::kLevel3_1,
+                        "0")};
++#endif
+ }
+ 
+ std::unique_ptr<H264Encoder> H264Encoder::Create(
+     const cricket::VideoCodec& codec) {
+   RTC_DCHECK(H264Encoder::IsSupported());
++
+ #if defined(WEBRTC_USE_H264)
+   RTC_CHECK(g_rtc_use_h264);
+   RTC_LOG(LS_INFO) << "Creating H264EncoderImpl.";
+diff --git a/modules/video_coding/codecs/h264/h264_decoder_mf_impl.cc b/modules/video_coding/codecs/h264/h264_decoder_mf_impl.cc
+new file mode 100644
+index 0000000000..a2964cd83f
+--- /dev/null
++++ b/modules/video_coding/codecs/h264/h264_decoder_mf_impl.cc
+@@ -0,0 +1,575 @@
++/*
++ *  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
++ *
++ *  Use of this source code is governed by a BSD-style license
++ *  that can be found in the LICENSE file in the root of the source
++ *  tree. An additional intellectual property rights grant can be found
++ *  in the file PATENTS.  All contributing project authors may
++ *  be found in the AUTHORS file in the root of the source tree.
++ *
++ */
++
++#include "modules/video_coding/codecs/h264/h264_decoder_mf_impl.h"
++
++#include <Windows.h>
++#include <codecapi.h>
++#include <mfapi.h>
++#include <mfidl.h>
++#include <mfreadwrite.h>
++#include <ppltasks.h>
++#include <robuffer.h>
++#include <wrl.h>
++#include <wrl\implements.h>
++#include <algorithm>
++#include <iomanip>
++#include <limits>
++#include <memory>
++#include "common_video/include/video_frame_buffer.h"
++#include "libyuv/convert.h"
++#include "modules/video_coding/include/video_codec_interface.h"
++#include "rtc_base/checks.h"
++#include "rtc_base/logging.h"
++
++#pragma comment(lib, "mfreadwrite")
++#pragma comment(lib, "mfplat")
++#pragma comment(lib, "mfuuid.lib")
++
++using Microsoft::WRL::ComPtr;
++#define ON_SUCCEEDED(act)                      \
++  if (SUCCEEDED(hr)) {                         \
++    hr = act;                                  \
++    if (FAILED(hr)) {                          \
++      RTC_LOG(LS_WARNING) << "ERROR:" << #act; \
++    }                                          \
++  }
++
++#include "api/video/color_space.h"
++#include "api/video/i010_buffer.h"
++#include "api/video/i420_buffer.h"
++#include "common_video/include/video_frame_buffer.h"
++#include "modules/video_coding/codecs/h264/h264_color_space.h"
++#include "rtc_base/checks.h"
++#include "rtc_base/critical_section.h"
++#include "rtc_base/keep_ref_until_done.h"
++#include "rtc_base/logging.h"
++#include "system_wrappers/include/field_trial.h"
++#include "system_wrappers/include/metrics.h"
++
++namespace webrtc {
++
++H264DecoderMFImpl::H264DecoderMFImpl()
++    : buffer_pool_(false, 300), /* max_number_of_buffers*/
++      width_(absl::nullopt),
++      height_(absl::nullopt),
++      decode_complete_callback_(nullptr) {}
++
++H264DecoderMFImpl::~H264DecoderMFImpl() {
++  OutputDebugString(L"H264DecoderMFImpl::~WinUWPH264DecoderImpl()\n");
++  Release();
++}
++
++HRESULT ConfigureOutputMediaType(ComPtr<IMFTransform> decoder, GUID media_type, bool* type_found) {
++  HRESULT hr = S_OK;
++  *type_found = false;
++
++  int type = 0;
++  while (true) {
++    ComPtr<IMFMediaType> output_media;
++    ON_SUCCEEDED(decoder->GetOutputAvailableType(0, type, &output_media));
++    if (hr == MF_E_NO_MORE_TYPES)
++      return S_OK;
++
++    GUID cur_type;
++    ON_SUCCEEDED(output_media->GetGUID(MF_MT_SUBTYPE, &cur_type));
++    if (FAILED(hr))
++      return hr;
++
++    if (cur_type == media_type) {
++      hr = decoder->SetOutputType(0, output_media.Get(), 0);
++      ON_SUCCEEDED(*type_found = true);
++      return hr;
++    }
++
++    type++;
++  }
++}
++
++HRESULT CreateInputMediaType(IMFMediaType** pp_input_media,
++                             absl::optional<UINT32> img_width,
++                             absl::optional<UINT32> img_height,
++                             absl::optional<UINT32> frame_rate) {
++  HRESULT hr = MFCreateMediaType(pp_input_media);
++
++  IMFMediaType* input_media = *pp_input_media;
++  ON_SUCCEEDED(input_media->SetGUID(MF_MT_MAJOR_TYPE, MFMediaType_Video));
++  ON_SUCCEEDED(input_media->SetGUID(MF_MT_SUBTYPE, MFVideoFormat_H264));
++  ON_SUCCEEDED(MFSetAttributeRatio(input_media, MF_MT_PIXEL_ASPECT_RATIO, 1, 1));
++  ON_SUCCEEDED(input_media->SetUINT32(MF_MT_INTERLACE_MODE, MFVideoInterlace_MixedInterlaceOrProgressive));
++
++  if (frame_rate.has_value()) {
++    ON_SUCCEEDED(MFSetAttributeRatio(input_media, MF_MT_FRAME_RATE, frame_rate.value(), 1));
++  }
++
++  if (img_width.has_value() && img_height.has_value()) {
++    ON_SUCCEEDED(MFSetAttributeSize(input_media, MF_MT_FRAME_SIZE, img_width.value(), img_height.value()));
++  }
++
++  return hr;
++}
++
++int32_t H264DecoderMFImpl::InitDecode(const VideoCodec* codec_settings, int32_t number_of_cores) {
++  if (codec_settings && codec_settings->codecType != kVideoCodecH264) {
++    return WEBRTC_VIDEO_CODEC_ERR_PARAMETER;
++  }
++
++  // Release necessary in case of re-initializing.
++  int32_t ret = Release();
++  if (ret != WEBRTC_VIDEO_CODEC_OK) {
++    return ret;
++  }
++
++  RTC_LOG(LS_INFO) << "H264DecoderMFImpl::InitDecode()\n";
++
++  width_ = codec_settings->width > 0 ? absl::optional<UINT32>(codec_settings->width) : absl::nullopt;
++  height_ = codec_settings->height > 0 ? absl::optional<UINT32>(codec_settings->height) : absl::nullopt;
++
++  HRESULT hr = S_OK;
++  ON_SUCCEEDED(CoInitializeEx(0, COINIT_APARTMENTTHREADED));
++  ON_SUCCEEDED(MFStartup(MF_VERSION, 0));
++
++  ON_SUCCEEDED(CoCreateInstance(CLSID_MSH264DecoderMFT, nullptr, CLSCTX_INPROC_SERVER, IID_IUnknown, (void**)&decoder_));
++
++  if (FAILED(hr)) {
++    RTC_LOG(LS_ERROR) << "Init failure: could not create Media Foundation H264 "
++                         "decoder instance.";
++    return WEBRTC_VIDEO_CODEC_ERROR;
++  }
++
++  // Try set decoder attributes
++  ComPtr<IMFAttributes> decoder_attrs;
++  ON_SUCCEEDED(decoder_->GetAttributes(decoder_attrs.GetAddressOf()));
++
++  if (SUCCEEDED(hr)) {
++    ON_SUCCEEDED(decoder_attrs->SetUINT32(CODECAPI_AVLowLatencyMode, TRUE));
++    if (FAILED(hr)) {
++      RTC_LOG(LS_WARNING) << "Init warning: failed to set low latency in H264 decoder.";
++      hr = S_OK;
++    }
++
++    ON_SUCCEEDED(decoder_attrs->SetUINT32(CODECAPI_AVDecVideoAcceleration_H264, TRUE));
++    if (FAILED(hr)) {
++      RTC_LOG(LS_WARNING) << "Init warning: failed to set HW accel in H264 decoder.";
++    }
++  }
++
++  // Clear any error from try set attributes
++  hr = S_OK;
++
++  ComPtr<IMFMediaType> input_media;
++  ON_SUCCEEDED(CreateInputMediaType(
++      input_media.GetAddressOf(), width_, height_,
++      codec_settings->maxFramerate > 0 ? absl::optional<UINT32>(codec_settings->maxFramerate) : absl::nullopt));
++
++  if (FAILED(hr)) {
++    RTC_LOG(LS_ERROR) << "Init failure: could not create input media type.";
++    return WEBRTC_VIDEO_CODEC_ERROR;
++  }
++
++  // Register the input type with the decoder
++  ON_SUCCEEDED(decoder_->SetInputType(0, input_media.Get(), 0));
++
++  if (FAILED(hr)) {
++    RTC_LOG(LS_ERROR) << "Init failure: failed to set input media type on decoder.";
++    return WEBRTC_VIDEO_CODEC_ERROR;
++  }
++
++  // Assert MF supports NV12 output
++  bool suitable_type_found;
++  ON_SUCCEEDED(ConfigureOutputMediaType(decoder_, MFVideoFormat_NV12, &suitable_type_found));
++
++  if (FAILED(hr) || !suitable_type_found) {
++    RTC_LOG(LS_ERROR) << "Init failure: failed to find a valid output media "
++                         "type for decoding.";
++    return WEBRTC_VIDEO_CODEC_ERROR;
++  }
++
++  DWORD status;
++  ON_SUCCEEDED(decoder_->GetInputStatus(0, &status));
++
++  // Validate that decoder is up and running
++  if (SUCCEEDED(hr)) {
++    if (MFT_INPUT_STATUS_ACCEPT_DATA != status)
++      // H.264 decoder MFT is not accepting data
++      return WEBRTC_VIDEO_CODEC_ERROR;
++  }
++
++  ON_SUCCEEDED(decoder_->ProcessMessage(MFT_MESSAGE_COMMAND_FLUSH, NULL));
++  ON_SUCCEEDED(decoder_->ProcessMessage(MFT_MESSAGE_NOTIFY_BEGIN_STREAMING, NULL));
++  ON_SUCCEEDED(decoder_->ProcessMessage(MFT_MESSAGE_NOTIFY_START_OF_STREAM, NULL));
++
++  inited_ = true;
++  return SUCCEEDED(hr) ? WEBRTC_VIDEO_CODEC_OK : WEBRTC_VIDEO_CODEC_ERROR;
++}
++
++/**
++ * Workaround [MF H264 bug: Output status is never set, even when ready]
++ *  => For now, always mark "ready" (results in extra buffer alloc/dealloc).
++ */
++HRESULT GetOutputStatus(ComPtr<IMFTransform> decoder, DWORD* output_status) {
++  HRESULT hr = decoder->GetOutputStatus(output_status);
++
++  // Don't MFT trust output status for now.
++  *output_status = MFT_OUTPUT_STATUS_SAMPLE_READY;
++  return hr;
++}
++
++/**
++ * Note: expected to return MF_E_TRANSFORM_NEED_MORE_INPUT and
++ *       MF_E_TRANSFORM_STREAM_CHANGE which must be handled by caller.
++ */
++HRESULT H264DecoderMFImpl::FlushFrames(uint32_t rtp_timestamp, uint64_t ntp_time_ms) {
++  HRESULT hr;
++  DWORD output_status;
++
++  while (SUCCEEDED(hr = GetOutputStatus(decoder_, &output_status)) && output_status == MFT_OUTPUT_STATUS_SAMPLE_READY) {
++    // Get needed size of our output buffer
++    MFT_OUTPUT_STREAM_INFO strm_info;
++    ON_SUCCEEDED(decoder_->GetOutputStreamInfo(0, &strm_info));
++    if (FAILED(hr)) {
++      RTC_LOG(LS_ERROR) << "Decode failure: failed to get output stream info.";
++      return hr;
++    }
++
++    // Create output sample
++    ComPtr<IMFMediaBuffer> out_buffer;
++    ON_SUCCEEDED(MFCreateMemoryBuffer(strm_info.cbSize, &out_buffer));
++    if (FAILED(hr)) {
++      RTC_LOG(LS_ERROR) << "Decode failure: output image memory buffer creation failed.";
++      return hr;
++    }
++
++    ComPtr<IMFSample> out_sample;
++    ON_SUCCEEDED(MFCreateSample(&out_sample));
++    if (FAILED(hr)) {
++      RTC_LOG(LS_ERROR) << "Decode failure: output in_sample creation failed.";
++      return hr;
++    }
++
++    ON_SUCCEEDED(out_sample->AddBuffer(out_buffer.Get()));
++    if (FAILED(hr)) {
++      RTC_LOG(LS_ERROR) << "Decode failure: failed to add buffer to output in_sample.";
++      return hr;
++    }
++
++    // Create output buffer description
++    MFT_OUTPUT_DATA_BUFFER output_data_buffer;
++    output_data_buffer.dwStatus = 0;
++    output_data_buffer.dwStreamID = 0;
++    output_data_buffer.pEvents = nullptr;
++    output_data_buffer.pSample = out_sample.Get();
++
++    // Invoke the Media Foundation decoder
++    // Note: we don't use ON_SUCCEEDED here since ProcessOutput returns
++    //       MF_E_TRANSFORM_NEED_MORE_INPUT often (too many log messages).
++    DWORD status;
++    hr = decoder_->ProcessOutput(0, 1, &output_data_buffer, &status);
++
++    if (FAILED(hr))
++      return hr; /* can return MF_E_TRANSFORM_NEED_MORE_INPUT or
++                    MF_E_TRANSFORM_STREAM_CHANGE (entirely acceptable) */
++
++    // Copy raw output sample data to video frame buffer.
++    ComPtr<IMFMediaBuffer> src_buffer;
++    ON_SUCCEEDED(out_sample->ConvertToContiguousBuffer(&src_buffer));
++    if (FAILED(hr)) {
++      RTC_LOG(LS_ERROR) << "Decode failure: failed to get contiguous buffer.";
++      return hr;
++    }
++
++    uint32_t width, height;
++    if (width_.has_value() && height_.has_value()) {
++      width = width_.value();
++      height = height_.value();
++    } else {
++      // Query the size from MF output media type
++      ComPtr<IMFMediaType> output_type;
++      ON_SUCCEEDED(decoder_->GetOutputCurrentType(0, output_type.GetAddressOf()));
++
++      ON_SUCCEEDED(MFGetAttributeSize(output_type.Get(), MF_MT_FRAME_SIZE, &width, &height));
++      if (FAILED(hr)) {
++        RTC_LOG(LS_ERROR) << "Decode failure: could not read image dimensions "
++                             "from Media Foundation, so the video frame buffer "
++                             "size can not be determined.";
++        return hr;
++      }
++
++      // Update members to avoid querying unnecessarily
++      width_.emplace(width);
++      height_.emplace(height);
++    }
++
++    rtc::scoped_refptr<I420Buffer> buffer = buffer_pool_.CreateBuffer(width, height);
++
++    if (!buffer.get()) {
++      // Pool has too many pending frames.
++      RTC_LOG(LS_WARNING) << "Decode warning: too many frames. Dropping frame.";
++      return WEBRTC_VIDEO_CODEC_NO_OUTPUT;
++    }
++
++    DWORD cur_length;
++    ON_SUCCEEDED(src_buffer->GetCurrentLength(&cur_length));
++    if (FAILED(hr)) {
++      RTC_LOG(LS_ERROR) << "Decode failure: could not get buffer length.";
++      return hr;
++    }
++
++    if (cur_length > 0) {
++      BYTE* src_data;
++      DWORD max_len, cur_len;
++      ON_SUCCEEDED(src_buffer->Lock(&src_data, &max_len, &cur_len));
++      if (FAILED(hr)) {
++        RTC_LOG(LS_ERROR) << "Decode failure: could lock buffer for copying.";
++        return hr;
++      }
++
++      // Convert NV12 to I420. Y and UV sections have same stride in NV12
++      // (width). The size of the Y section is the size of the frame, since Y
++      // luminance values are 8-bits each.
++      libyuv::NV12ToI420(src_data, width, src_data + (width * height), width, buffer->MutableDataY(), buffer->StrideY(),
++                         buffer->MutableDataU(), buffer->StrideU(), buffer->MutableDataV(), buffer->StrideV(), width, height);
++
++      ON_SUCCEEDED(src_buffer->Unlock());
++      if (FAILED(hr))
++        return hr;
++    }
++
++    // LONGLONG sample_time; /* unused */
++    // ON_SUCCEEDED(spOutSample->GetSampleTime(&sample_time));
++
++    // TODO: Ideally, we should convert sample_time (above) back to 90khz + base
++    // and use it in place of rtp_timestamp, since MF may interpolate it.
++    // Instead, we ignore the MFT sample time out, using rtp from in frame that
++    // triggered this decoded frame.
++    VideoFrame decoded_frame(buffer, rtp_timestamp, 0, kVideoRotation_0);
++
++    // Use ntp time from the earliest frame
++    decoded_frame.set_ntp_time_ms(ntp_time_ms);
++
++    // Emit image to downstream
++    if (decode_complete_callback_ != nullptr) {
++      decode_complete_callback_->Decoded(decoded_frame, absl::nullopt, absl::nullopt);
++    }
++  }
++
++  return hr;
++}
++
++/**
++ * Note: acceptable to return MF_E_NOTACCEPTING (though it shouldn't since
++ * last loop should've flushed)
++ */
++HRESULT H264DecoderMFImpl::EnqueueFrame(const EncodedImage& input_image, bool missing_frames) {
++  HRESULT hr = S_OK;
++
++  // Create a MF buffer from our data
++  ComPtr<IMFMediaBuffer> in_buffer;
++  // ON_SUCCEEDED(MFCreateMemoryBuffer(input_image._length, &in_buffer));
++  ON_SUCCEEDED(MFCreateMemoryBuffer(input_image.size(), &in_buffer));
++  if (FAILED(hr)) {
++    RTC_LOG(LS_ERROR) << "Decode failure: input image memory buffer creation failed.";
++    return hr;
++  }
++
++  DWORD max_len, cur_len;
++  BYTE* data;
++  ON_SUCCEEDED(in_buffer->Lock(&data, &max_len, &cur_len));
++  if (FAILED(hr))
++    return hr;
++
++  // memcpy(data, input_image._buffer, input_image._length);
++  memcpy(data, input_image.buffer(), input_image.size());
++
++  ON_SUCCEEDED(in_buffer->Unlock());
++  if (FAILED(hr))
++    return hr;
++
++  // ON_SUCCEEDED(in_buffer->SetCurrentLength(input_image._length));
++  ON_SUCCEEDED(in_buffer->SetCurrentLength(input_image.size()));
++  if (FAILED(hr))
++    return hr;
++
++  // Create a sample from media buffer
++  ComPtr<IMFSample> in_sample;
++  ON_SUCCEEDED(MFCreateSample(&in_sample));
++  if (FAILED(hr)) {
++    RTC_LOG(LS_ERROR) << "Decode failure: input in_sample creation failed.";
++    return hr;
++  }
++
++  ON_SUCCEEDED(in_sample->AddBuffer(in_buffer.Get()));
++  if (FAILED(hr)) {
++    RTC_LOG(LS_ERROR) << "Decode failure: failed to add buffer to input in_sample.";
++    return hr;
++  }
++
++  int64_t sample_time_ms;
++  if (first_frame_rtp_ == 0) {
++    first_frame_rtp_ = input_image.Timestamp();
++    sample_time_ms = 0;
++  } else {
++    // Convert from 90 khz, rounding to nearest ms.
++    sample_time_ms = (static_cast<uint64_t>(input_image.Timestamp()) - first_frame_rtp_) / 90.0 + 0.5f;
++  }
++
++  ON_SUCCEEDED(in_sample->SetSampleTime(sample_time_ms * 10000 /* convert milliseconds to 100-nanosecond unit */));
++  if (FAILED(hr)) {
++    RTC_LOG(LS_ERROR) << "Decode failure: failed to set in_sample time on input in_sample.";
++    return hr;
++  }
++
++  // Set sample attributes
++  ComPtr<IMFAttributes> sample_attrs;
++  ON_SUCCEEDED(in_sample.As(&sample_attrs));
++
++  if (FAILED(hr)) {
++    RTC_LOG(LS_ERROR) << "Decode warning: failed to set image attributes for frame.";
++    hr = S_OK;
++  } else {
++    // if (input_image._frameType == kVideoFrameKey &&
++    if (input_image._frameType == VideoFrameType::kVideoFrameKey && input_image._completeFrame) {
++      ON_SUCCEEDED(sample_attrs->SetUINT32(MFSampleExtension_CleanPoint, TRUE));
++      hr = S_OK;
++    }
++
++    if (missing_frames) {
++      ON_SUCCEEDED(sample_attrs->SetUINT32(MFSampleExtension_Discontinuity, TRUE));
++      hr = S_OK;
++    }
++  }
++
++  // Enqueue sample with Media Foundation
++  ON_SUCCEEDED(decoder_->ProcessInput(0, in_sample.Get(), 0));
++  return hr;
++}
++
++int32_t H264DecoderMFImpl::Release() {
++  OutputDebugString(L"WinUWPH264DecoderImpl::Release()\n");
++  HRESULT hr = S_OK;
++  inited_ = false;
++
++  // Release I420 frame buffer pool
++  buffer_pool_.Release();
++
++  if (decoder_ != NULL) {
++    // Follow shutdown procedure gracefully. On fail, continue anyway.
++    ON_SUCCEEDED(decoder_->ProcessMessage(MFT_MESSAGE_NOTIFY_END_OF_STREAM, 0));
++    ON_SUCCEEDED(decoder_->ProcessMessage(MFT_MESSAGE_COMMAND_DRAIN, NULL));
++    ON_SUCCEEDED(decoder_->ProcessMessage(MFT_MESSAGE_COMMAND_FLUSH, NULL));
++    decoder_ = nullptr;
++  }
++
++  MFShutdown();
++  CoUninitialize();
++
++  return WEBRTC_VIDEO_CODEC_OK;
++}
++
++int32_t H264DecoderMFImpl::RegisterDecodeCompleteCallback(DecodedImageCallback* callback) {
++  rtc::CritScope lock(&crit_);
++
++  decode_complete_callback_ = callback;
++  return WEBRTC_VIDEO_CODEC_OK;
++}
++
++int32_t H264DecoderMFImpl::Decode(const EncodedImage& input_image,
++                                  // bool /*missing_frames*/,
++                                  bool missing_frames,
++                                  int64_t /*render_time_ms*/) {
++  if (!decode_complete_callback_) {
++    RTC_LOG(LS_WARNING) << "InitDecode() has been called, but a callback function "
++                           "has not been set with RegisterDecodeCompleteCallback()";
++    return WEBRTC_VIDEO_CODEC_UNINITIALIZED;
++  }
++  if (!input_image.data() || !input_image.size()) {
++    return WEBRTC_VIDEO_CODEC_ERR_PARAMETER;
++  }
++
++  if (input_image.size() > static_cast<size_t>(std::numeric_limits<int>::max())) {
++    return WEBRTC_VIDEO_CODEC_ERROR;
++  }
++
++  HRESULT hr = S_OK;
++
++  if (!inited_) {
++    return WEBRTC_VIDEO_CODEC_UNINITIALIZED;
++  }
++
++  if (decode_complete_callback_ == NULL) {
++    return WEBRTC_VIDEO_CODEC_UNINITIALIZED;
++  }
++
++  if (input_image.buffer() == NULL && input_image.size() > 0) {
++    return WEBRTC_VIDEO_CODEC_ERR_PARAMETER;
++  }
++
++  // Discard until keyframe.
++  if (require_keyframe_) {
++    if (input_image._frameType != VideoFrameType::kVideoFrameKey || !input_image._completeFrame) {
++      return WEBRTC_VIDEO_CODEC_ERROR;
++    } else {
++      require_keyframe_ = false;
++    }
++  }
++
++  // Enqueue the new frame with Media Foundation
++  ON_SUCCEEDED(EnqueueFrame(input_image, missing_frames));
++  if (hr == MF_E_NOTACCEPTING) {
++    // For robustness (shouldn't happen). Flush any old MF data blocking the
++    // new frames.
++    hr = decoder_->ProcessMessage(MFT_MESSAGE_COMMAND_FLUSH, NULL);
++
++    if (input_image._frameType == VideoFrameType::kVideoFrameKey) {
++      ON_SUCCEEDED(EnqueueFrame(input_image, missing_frames));
++    } else {
++      require_keyframe_ = true;
++      return WEBRTC_VIDEO_CODEC_ERROR;
++    }
++  }
++
++  if (FAILED(hr))
++    return WEBRTC_VIDEO_CODEC_ERROR;
++
++  // Flush any decoded samples resulting from new frame, invoking callback
++  hr = FlushFrames(input_image.Timestamp(), input_image.ntp_time_ms_);
++
++  if (hr == MF_E_TRANSFORM_STREAM_CHANGE) {
++    // Output media type is no longer suitable. Reconfigure and retry.
++    bool suitable_type_found;
++    hr = ConfigureOutputMediaType(decoder_, MFVideoFormat_NV12, &suitable_type_found);
++
++    if (FAILED(hr) || !suitable_type_found)
++      return WEBRTC_VIDEO_CODEC_ERROR;
++
++    // Reset width and height in case output media size has changed (though it
++    // seems that would be unexpected, given that the input media would need to
++    // be manually changed too).
++    width_.reset();
++    height_.reset();
++
++    hr = FlushFrames(input_image.Timestamp(), input_image.ntp_time_ms_);
++  }
++
++  if (SUCCEEDED(hr) || hr == MF_E_TRANSFORM_NEED_MORE_INPUT) {
++    return WEBRTC_VIDEO_CODEC_OK;
++  }
++
++  return WEBRTC_VIDEO_CODEC_ERROR;
++}
++
++const char* H264DecoderMFImpl::ImplementationName() const {
++  return "WinRTC_MF_H264";
++}
++
++}  // namespace webrtc
++
++//#endif  // WEBRTC_USE_H264
+diff --git a/modules/video_coding/codecs/h264/h264_decoder_mf_impl.h b/modules/video_coding/codecs/h264/h264_decoder_mf_impl.h
+new file mode 100644
+index 0000000000..c3bac1cc68
+--- /dev/null
++++ b/modules/video_coding/codecs/h264/h264_decoder_mf_impl.h
+@@ -0,0 +1,85 @@
++/*
++ *  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
++ *
++ *  Use of this source code is governed by a BSD-style license
++ *  that can be found in the LICENSE file in the root of the source
++ *  tree. An additional intellectual property rights grant can be found
++ *  in the file PATENTS.  All contributing project authors may
++ *  be found in the AUTHORS file in the root of the source tree.
++ *
++ */
++
++#ifndef MODULES_VIDEO_CODING_CODECS_H264_H264_DECODER_MF_IMPL_H_
++#define MODULES_VIDEO_CODING_CODECS_H264_H264_DECODER_MF_IMPL_H_
++
++#include <memory>
++
++//
++// WebRTC-UWP Begin
++//
++#include <mfapi.h>
++#include <mfidl.h>
++#include <Mfreadwrite.h>
++#include <mferror.h>
++#include <wrl.h>
++
++#include "rtc_base/critical_section.h"
++
++#pragma comment(lib, "mfreadwrite")
++#pragma comment(lib, "mfplat")
++#pragma comment(lib, "mfuuid")
++//
++// WebRTC-UWP End
++//
++
++#include "modules/video_coding/codecs/h264/include/h264.h"
++#include "common_video/include/i420_buffer_pool.h"
++
++namespace webrtc {
++
++class H264DecoderMFImpl : public H264Decoder {
++ public:
++  H264DecoderMFImpl();
++  ~H264DecoderMFImpl() override;
++
++  // If |codec_settings| is NULL it is ignored. If it is not NULL,
++  // |codec_settings->codecType| must be |kVideoCodecH264|.
++  int32_t InitDecode(const VideoCodec* codec_settings,
++                     int32_t number_of_cores) override;
++  int32_t Release() override;
++
++  int32_t RegisterDecodeCompleteCallback(
++      DecodedImageCallback* callback) override;
++
++  // |missing_frames|, |fragmentation| and |render_time_ms| are ignored.
++  int32_t Decode(const EncodedImage& input_image,
++                 bool /*missing_frames*/,
++                 int64_t render_time_ms = -1) override;
++
++  const char* ImplementationName() const override;
++
++ private:
++   //
++   // WebRTC-UWP Begin
++   //
++  HRESULT FlushFrames(uint32_t timestamp, uint64_t ntp_time_ms);
++  HRESULT EnqueueFrame(const EncodedImage& input_image, bool missing_frames);
++
++ private:
++  Microsoft::WRL::ComPtr<IMFTransform> decoder_;
++  I420BufferPool buffer_pool_;
++
++  bool inited_ = false;
++  bool require_keyframe_ = true;
++  uint32_t first_frame_rtp_ = 0;
++  absl::optional<uint32_t> width_;
++  absl::optional<uint32_t> height_;
++  rtc::CriticalSection crit_;
++  DecodedImageCallback* decode_complete_callback_;
++};
++
++}  // namespace webrtc
++
++//#endif  // WEBRTC_USE_H264
++
++#endif  // MODULES_VIDEO_CODING_CODECS_H264_H264_DECODER_MF_IMPL_H_
+diff --git a/modules/video_coding/codecs/h264/win/encoder/h264_encoder_mf_impl.cc b/modules/video_coding/codecs/h264/win/encoder/h264_encoder_mf_impl.cc
+new file mode 100644
+index 0000000000..0159b0fa08
+--- /dev/null
++++ b/modules/video_coding/codecs/h264/win/encoder/h264_encoder_mf_impl.cc
+@@ -0,0 +1,551 @@
++/*
++ *  Copyright (c) 2020 The WebRTC project authors. All Rights Reserved.
++ *
++ *  Use of this source code is governed by a BSD-style license
++ *  that can be found in the LICENSE file in the root of the source
++ *  tree. An additional intellectual property rights grant can be found
++ *  in the file PATENTS.  All contributing project authors may
++ *  be found in the AUTHORS file in the root of the source tree.
++ *
++ */
++
++#include "modules/video_coding/codecs/h264/win/encoder/h264_encoder_mf_impl.h"
++
++#include <codecapi.h>
++#include <mfapi.h>
++#include "absl/strings/match.h"
++#include "libyuv/convert.h"
++#include "modules/video_coding/codecs/h264/win/utils/utils.h"
++#include "rtc_base/logging.h"
++#include "rtc_base/time_utils.h"
++
++namespace webrtc {
++
++// QP scaling thresholds.
++static const int kLowH264QpThreshold = 24;
++static const int kHighH264QpThreshold = 37;
++
++// Used by histograms. Values of entries should not be changed.
++enum H264EncoderMFImplEvent {
++  kH264EncoderEventInit = 0,
++  kH264EncoderEventError = 1,
++  kH264EncoderEventMax = 16,
++};
++H264EncoderMFImpl::H264EncoderMFImpl(const cricket::VideoCodec& codec) {
++  HRESULT hr = S_OK;
++
++  RTC_CHECK(absl::EqualsIgnoreCase(codec.name, cricket::kH264CodecName));
++
++  ON_SUCCEEDED(MFStartup(MF_VERSION, MFSTARTUP_NOSOCKET));
++}
++
++H264EncoderMFImpl::~H264EncoderMFImpl() {
++  HRESULT hr = S_OK;
++
++  Release();
++
++  ON_SUCCEEDED(MFShutdown());
++}
++
++int H264EncoderMFImpl::InitEncoderWithSettings(
++    const VideoCodec* codec_settings) {
++  HRESULT hr = S_OK;
++
++  rtc::CritScope lock(&crit_);
++
++  // output media type (h264)
++  ComPtr<IMFMediaType> mediaTypeOut;
++  ON_SUCCEEDED(MFCreateMediaType(&mediaTypeOut));
++  ON_SUCCEEDED(mediaTypeOut->SetGUID(MF_MT_MAJOR_TYPE, MFMediaType_Video));
++  ON_SUCCEEDED(mediaTypeOut->SetGUID(MF_MT_SUBTYPE, MFVideoFormat_H264));
++  // Lumia 635 and Lumia 1520 Windows phones don't work well
++  // with constrained baseline profile.
++  // ON_SUCCEEDED(mediaTypeOut->SetUINT32(MF_MT_MPEG2_PROFILE,
++  // eAVEncH264VProfile_ConstrainedBase));
++
++  // Weight*Height*2 kbit represents a good balance between video quality and
++  // the bandwidth that a 620 Windows phone can handle.
++  ON_SUCCEEDED(mediaTypeOut->SetUINT32(MF_MT_AVG_BITRATE, target_bps_));
++  ON_SUCCEEDED(mediaTypeOut->SetUINT32(MF_MT_INTERLACE_MODE,
++                                       MFVideoInterlace_Progressive));
++  ON_SUCCEEDED(MFSetAttributeSize(mediaTypeOut.Get(), MF_MT_FRAME_SIZE, width_,
++                                  height_));
++  ON_SUCCEEDED(MFSetAttributeRatio(mediaTypeOut.Get(), MF_MT_FRAME_RATE,
++                                   max_frame_rate_, 1));
++
++  // input media type (nv12)
++  ComPtr<IMFMediaType> mediaTypeIn;
++  ON_SUCCEEDED(MFCreateMediaType(&mediaTypeIn));
++  ON_SUCCEEDED(mediaTypeIn->SetGUID(MF_MT_MAJOR_TYPE, MFMediaType_Video));
++  ON_SUCCEEDED(mediaTypeIn->SetGUID(MF_MT_SUBTYPE, MFVideoFormat_NV12));
++  ON_SUCCEEDED(mediaTypeIn->SetUINT32(MF_MT_INTERLACE_MODE,
++                                      MFVideoInterlace_Progressive));
++  ON_SUCCEEDED(mediaTypeIn->SetUINT32(MF_MT_ALL_SAMPLES_INDEPENDENT, TRUE));
++  ON_SUCCEEDED(
++      MFSetAttributeSize(mediaTypeIn.Get(), MF_MT_FRAME_SIZE, width_, height_));
++  ON_SUCCEEDED(MFSetAttributeRatio(mediaTypeIn.Get(), MF_MT_FRAME_RATE,
++                                   max_frame_rate_, 1));
++
++  // Create the media sink
++  ON_SUCCEEDED(Microsoft::WRL::MakeAndInitialize<H264MediaSink>(
++      mediaSink_.ReleaseAndGetAddressOf()));
++
++  // SinkWriter creation attributes
++  ON_SUCCEEDED(MFCreateAttributes(
++      sinkWriterCreationAttributes_.ReleaseAndGetAddressOf(), 1));
++  ON_SUCCEEDED(sinkWriterCreationAttributes_->SetUINT32(
++      MF_READWRITE_ENABLE_HARDWARE_TRANSFORMS, TRUE));
++  ON_SUCCEEDED(sinkWriterCreationAttributes_->SetUINT32(
++      MF_SINK_WRITER_DISABLE_THROTTLING, TRUE));
++  ON_SUCCEEDED(sinkWriterCreationAttributes_->SetUINT32(MF_LOW_LATENCY, TRUE));
++
++  // Create the sink writer
++  ON_SUCCEEDED(MFCreateSinkWriterFromMediaSink(
++      mediaSink_.Get(), sinkWriterCreationAttributes_.Get(),
++      sinkWriter_.ReleaseAndGetAddressOf()));
++
++  // Add the h264 output stream to the writer
++  ON_SUCCEEDED(sinkWriter_->AddStream(mediaTypeOut.Get(), &streamIndex_));
++
++  // SinkWriter encoder properties
++  ON_SUCCEEDED(MFCreateAttributes(
++      sinkWriterEncoderAttributes_.ReleaseAndGetAddressOf(), 1));
++  ON_SUCCEEDED(
++      sinkWriter_->SetInputMediaType(streamIndex_, mediaTypeIn.Get(), nullptr));
++
++  // Register this as the callback for encoded samples.
++  ON_SUCCEEDED(mediaSink_->RegisterEncodingCallback(this));
++
++  ON_SUCCEEDED(sinkWriter_->BeginWriting());
++
++  codec_ = *codec_settings;
++
++  if (SUCCEEDED(hr)) {
++    inited_ = true;
++    lastTimeSettingsChanged_ = rtc::TimeMillis();
++    return WEBRTC_VIDEO_CODEC_OK;
++  } else {
++    return hr;
++  }
++}
++
++//
++int32_t H264EncoderMFImpl::InitEncode(const VideoCodec* inst,
++                                      const VideoEncoder::Settings& settings) {
++  if (!inst || inst->codecType != kVideoCodecH264) {
++    RTC_LOG(LS_ERROR) << "H264 UWP Encoder not registered as H264 codec";
++    return WEBRTC_VIDEO_CODEC_ERR_PARAMETER;
++  }
++  if (inst->maxFramerate == 0) {
++    RTC_LOG(LS_ERROR) << "H264 UWP Encoder has no framerate defined";
++    return WEBRTC_VIDEO_CODEC_ERR_PARAMETER;
++  }
++  if (inst->width < 1 || inst->height < 1) {
++    RTC_LOG(LS_ERROR) << "H264 UWP Encoder has no valid frame size defined";
++    return WEBRTC_VIDEO_CODEC_ERR_PARAMETER;
++  }
++
++  width_ = inst->width;
++  height_ = inst->height;
++  target_bps_ = inst->startBitrate > 0 ? inst->startBitrate * 1000
++                                       : width_ * height_ * 2.0;
++
++  max_frame_rate_ = inst->maxFramerate;
++  if (target_bps_ == 0) {
++    target_bps_ = inst->startBitrate * 1000;
++  } else {
++    target_bps_ = inst->maxBitrate * 1000;
++  }
++  return InitEncoderWithSettings(inst);
++}
++
++int32_t H264EncoderMFImpl::Release() {
++  // Use a temporary sink variable to prevent lock inversion
++  // between the shutdown call and OnH264Encoded() callback.
++  ComPtr<H264MediaSink> tmpMediaSink;
++
++  {
++    rtc::CritScope lock(&crit_);
++    sinkWriter_.Reset();
++    if (mediaSink_ != nullptr) {
++      tmpMediaSink = mediaSink_;
++    }
++    sinkWriterCreationAttributes_.Reset();
++    sinkWriterEncoderAttributes_.Reset();
++    mediaSink_.Reset();
++    startTime_ = 0;
++    lastTimestampHns_ = 0;
++    firstFrame_ = true;
++    inited_ = false;
++    framePendingCount_ = 0;
++    _sampleAttributeQueue.clear();
++    rtc::CritScope callbackLock(&callbackCrit_);
++    encodedCompleteCallback_ = nullptr;
++  }
++
++  if (tmpMediaSink != nullptr) {
++    tmpMediaSink->Shutdown();
++  }
++  return WEBRTC_VIDEO_CODEC_OK;
++}
++
++int32_t H264EncoderMFImpl::RegisterEncodeCompleteCallback(
++    EncodedImageCallback* callback) {
++  rtc::CritScope lock(&callbackCrit_);
++  encodedCompleteCallback_ = callback;
++  return WEBRTC_VIDEO_CODEC_OK;
++}
++
++void H264EncoderMFImpl::SetRates(const RateControlParameters& parameters) {
++  RTC_LOG(LS_INFO) << "H264EncoderMFImpl::SetRates("
++                   << parameters.bitrate.get_sum_bps() << "bps "
++                   << parameters.framerate_fps << "fps)";
++
++  // This may happen.  Ignore it.
++  if (parameters.framerate_fps == 0) {
++    max_frame_rate_ = codec_.maxFramerate;
++  }
++
++  rtc::CritScope lock(&crit_);
++  if (sinkWriter_ == nullptr) {
++    return;
++  }
++
++  bool bitrateUpdated = false;
++  bool fpsUpdated = false;
++
++#ifdef DYNAMIC_BITRATE
++  if (target_bps_ != (parameters.bitrate.get_sum_bps() * 1000)) {
++    target_bps_ = parameters.bitrate.get_sum_bps() * 1000;
++    bitrateUpdated = true;
++  }
++#endif
++
++#ifdef DYNAMIC_FPS
++  // Fps changes seems to be expensive, make it granular to several frames per
++  // second.
++  if (max_frame_rate_ != parameters.framerate_fps &&
++      std::abs((int)max_frame_rate_ - (int)parameters.framerate_fps) > 5) {
++    max_frame_rate_ = parameters.framerate_fps;
++    fpsUpdated = true;
++  }
++#endif
++
++  if (bitrateUpdated || fpsUpdated) {
++    if ((rtc::TimeMillis() - lastTimeSettingsChanged_) < 15000) {
++      RTC_LOG(LS_INFO) << "Last time settings changed was too soon, skipping "
++                          "this SetRates().\n";
++      return;
++    }
++
++    EncodedImageCallback* tempCallback = encodedCompleteCallback_;
++    Release();
++    {
++      rtc::CritScope lock(&callbackCrit_);
++      encodedCompleteCallback_ = tempCallback;
++    }
++    InitEncoderWithSettings(&codec_);
++  }
++}
++
++int32_t H264EncoderMFImpl::Encode(
++    const VideoFrame& input_frame,
++    const std::vector<VideoFrameType>* frame_types) {
++  {
++    rtc::CritScope lock(&crit_);
++    if (!inited_) {
++      return -1;
++    }
++  }
++
++  bool is_key_frame_forced = false;
++
++  if (frame_types != nullptr) {
++    for (auto frameType : *frame_types) {
++      if (frameType == VideoFrameType::kVideoFrameKey) {
++        RTC_LOG(LS_INFO) << "Key frame requested in H264 encoder.";
++        ComPtr<IMFSinkWriterEncoderConfig> encoderConfig;
++        sinkWriter_.As(&encoderConfig);
++        ComPtr<IMFAttributes> encoderAttributes;
++        MFCreateAttributes(&encoderAttributes, 1);
++        encoderAttributes->SetUINT32(CODECAPI_AVEncVideoForceKeyFrame, TRUE);
++        encoderConfig->PlaceEncodingParameters(streamIndex_,
++                                               encoderAttributes.Get());
++        is_key_frame_forced = true;
++        break;
++      }
++    }
++  }
++
++  HRESULT hr = S_OK;
++
++  ComPtr<IMFSample> sample;
++  {
++    rtc::CritScope lock(&crit_);
++    if (_sampleAttributeQueue.size() > 2) {
++      return WEBRTC_VIDEO_CODEC_OK;
++    }
++    sample = FromVideoFrame(input_frame);
++  }
++
++  ON_SUCCEEDED(sinkWriter_->WriteSample(streamIndex_, sample.Get()));
++
++  rtc::CritScope lock(&crit_);
++  // Some threads online mention this is useful to do regularly.
++  ++frameCount_;
++  if (frameCount_ % 30 == 0) {
++    ON_SUCCEEDED(sinkWriter_->NotifyEndOfSegment(streamIndex_));
++  }
++
++  ++framePendingCount_;
++
++  if (is_key_frame_forced) {
++    RTC_LOG(LS_INFO) << "Stop forcing key frames in the H264 encoder.";
++    ComPtr<IMFSinkWriterEncoderConfig> encoderConfig;
++    sinkWriter_.As(&encoderConfig);
++    ComPtr<IMFAttributes> encoderAttributes;
++    MFCreateAttributes(&encoderAttributes, 1);
++    encoderAttributes->SetUINT32(CODECAPI_AVEncVideoForceKeyFrame, FALSE);
++    encoderConfig->PlaceEncodingParameters(streamIndex_,
++                                           encoderAttributes.Get());
++  }
++
++  return WEBRTC_VIDEO_CODEC_OK;
++}
++
++VideoEncoder::EncoderInfo H264EncoderMFImpl::GetEncoderInfo() const {
++  EncoderInfo info;
++  info.supports_native_handle = false;
++  info.implementation_name = "WinRTC_MF_H264";
++  info.scaling_settings =
++      VideoEncoder::ScalingSettings(kLowH264QpThreshold, kHighH264QpThreshold);
++  info.is_hardware_accelerated = true;
++  info.has_internal_source = false;
++  info.supports_simulcast = false;
++  return info;
++}
++
++void H264EncoderMFImpl::OnH264Encoded(ComPtr<IMFSample> sample) {
++  DWORD totalLength;
++  HRESULT hr = S_OK;
++  ON_SUCCEEDED(sample->GetTotalLength(&totalLength));
++
++  ComPtr<IMFMediaBuffer> buffer;
++  hr = sample->GetBufferByIndex(0, &buffer);
++
++  if (SUCCEEDED(hr)) {
++    BYTE* byteBuffer;
++    DWORD maxLength;
++    DWORD curLength;
++    hr = buffer->Lock(&byteBuffer, &maxLength, &curLength);
++    if (FAILED(hr)) {
++      return;
++    }
++    if (curLength == 0) {
++      RTC_LOG(LS_WARNING) << "Got empty sample.";
++      buffer->Unlock();
++      return;
++    }
++    std::vector<byte> sendBuffer;
++    sendBuffer.resize(curLength);
++    memcpy(sendBuffer.data(), byteBuffer, curLength);
++    hr = buffer->Unlock();
++    if (FAILED(hr)) {
++      return;
++    }
++
++    // sendBuffer is not copied here.
++    EncodedImage encodedImage(sendBuffer.data(), curLength, curLength);
++
++    ComPtr<IMFAttributes> sampleAttributes;
++    hr = sample.As(&sampleAttributes);
++    if (SUCCEEDED(hr)) {
++      UINT32 cleanPoint;
++      hr = sampleAttributes->GetUINT32(MFSampleExtension_CleanPoint,
++                                       &cleanPoint);
++      if (SUCCEEDED(hr) && cleanPoint) {
++        encodedImage._completeFrame = true;
++        encodedImage._frameType = VideoFrameType::kVideoFrameKey;
++      }
++    }
++
++    // Scan for and create mark all fragments.
++    RTPFragmentationHeader fragmentationHeader;
++    uint32_t fragIdx = 0;
++    for (uint32_t i = 0; i < sendBuffer.size() - 5; ++i) {
++      byte* ptr = sendBuffer.data() + i;
++      int prefixLengthFound = 0;
++      if (ptr[0] == 0x00 && ptr[1] == 0x00 && ptr[2] == 0x00 &&
++          ptr[3] == 0x01 &&
++          ((ptr[4] & 0x1f) != 0x09 /* ignore access unit delimiters */)) {
++        prefixLengthFound = 4;
++      } else if (ptr[0] == 0x00 && ptr[1] == 0x00 && ptr[2] == 0x01 &&
++                 ((ptr[3] & 0x1f) !=
++                  0x09 /* ignore access unit delimiters */)) {
++        prefixLengthFound = 3;
++      }
++
++      // Found a key frame, mark is as such in case
++      // MFSampleExtension_CleanPoint wasn't set on the sample.
++      if (prefixLengthFound > 0 && (ptr[prefixLengthFound] & 0x1f) == 0x05) {
++        encodedImage._completeFrame = true;
++        encodedImage._frameType = VideoFrameType::kVideoFrameKey;
++      }
++
++      if (prefixLengthFound > 0) {
++        fragmentationHeader.VerifyAndAllocateFragmentationHeader(fragIdx + 1);
++        fragmentationHeader.fragmentationOffset[fragIdx] =
++            i + prefixLengthFound;
++        fragmentationHeader.fragmentationLength[fragIdx] =
++            0;  // We'll set that later
++        // Set the length of the previous fragment.
++        if (fragIdx > 0) {
++          fragmentationHeader.fragmentationLength[fragIdx - 1] =
++              i - fragmentationHeader.fragmentationOffset[fragIdx - 1];
++        }
++        ++fragIdx;
++        i += 5;
++      }
++    }
++    // Set the length of the last fragment.
++    if (fragIdx > 0) {
++      fragmentationHeader.fragmentationLength[fragIdx - 1] =
++          sendBuffer.size() -
++          fragmentationHeader.fragmentationOffset[fragIdx - 1];
++    }
++
++    {
++      rtc::CritScope lock(&callbackCrit_);
++      --framePendingCount_;
++      if (encodedCompleteCallback_ == nullptr) {
++        return;
++      }
++
++      LONGLONG sampleTimestamp;
++      sample->GetSampleTime(&sampleTimestamp);
++
++      CachedFrameAttributes frameAttributes;
++      if (_sampleAttributeQueue.pop(sampleTimestamp, frameAttributes)) {
++        encodedImage.SetTimestamp(frameAttributes.timestamp);
++        encodedImage.ntp_time_ms_ = frameAttributes.ntpTime;
++        encodedImage.capture_time_ms_ = frameAttributes.captureRenderTime;
++        encodedImage._encodedWidth = frameAttributes.frameWidth;
++        encodedImage._encodedHeight = frameAttributes.frameHeight;
++      } else {
++        // No point in confusing the callback with a frame that doesn't
++        // have correct attributes.
++        return;
++      }
++
++      if (encodedCompleteCallback_ != nullptr) {
++        CodecSpecificInfo codecSpecificInfo;
++        codecSpecificInfo.codecType = webrtc::kVideoCodecH264;
++        codecSpecificInfo.codecSpecific.H264.packetization_mode =
++            H264PacketizationMode::NonInterleaved;
++        encodedCompleteCallback_->OnEncodedImage(
++            encodedImage, &codecSpecificInfo, &fragmentationHeader);
++      }
++    }
++  }
++}
++
++ComPtr<IMFSample> H264EncoderMFImpl::FromVideoFrame(const VideoFrame& frame) {
++  HRESULT hr = S_OK;
++  ComPtr<IMFSample> sample;
++  ON_SUCCEEDED(MFCreateSample(sample.ReleaseAndGetAddressOf()));
++
++  ComPtr<IMFAttributes> sampleAttributes;
++  ON_SUCCEEDED(sample.As(&sampleAttributes));
++
++  rtc::scoped_refptr<I420BufferInterface> frameBuffer =
++      static_cast<I420BufferInterface*>(frame.video_frame_buffer().get());
++
++  if (SUCCEEDED(hr)) {
++    auto totalSize = frameBuffer->StrideY() * frameBuffer->height() +
++                     frameBuffer->StrideU() * (frameBuffer->height() + 1) / 2 +
++                     frameBuffer->StrideV() * (frameBuffer->height() + 1) / 2;
++
++    ComPtr<IMFMediaBuffer> mediaBuffer;
++    ON_SUCCEEDED(MFCreateMemoryBuffer(totalSize, mediaBuffer.ReleaseAndGetAddressOf()));
++
++    BYTE* destBuffer = nullptr;
++    if (SUCCEEDED(hr)) {
++      DWORD cbMaxLength;
++      DWORD cbCurrentLength;
++      ON_SUCCEEDED(
++          mediaBuffer->Lock(&destBuffer, &cbMaxLength, &cbCurrentLength));
++    }
++
++    if (SUCCEEDED(hr)) {
++      BYTE* destUV =
++          destBuffer + (frameBuffer->StrideY() * frameBuffer->height());
++      libyuv::I420ToNV12(
++          frameBuffer->DataY(), frameBuffer->StrideY(), frameBuffer->DataU(),
++          frameBuffer->StrideU(), frameBuffer->DataV(), frameBuffer->StrideV(),
++          destBuffer, frameBuffer->StrideY(), destUV, frameBuffer->StrideY(),
++          frameBuffer->width(), frameBuffer->height());
++    }
++
++    {
++      if (frameBuffer->width() != (int)width_ ||
++          frameBuffer->height() != (int)height_) {
++        EncodedImageCallback* tempCallback = encodedCompleteCallback_;
++        Release();
++        {
++          rtc::CritScope lock(&callbackCrit_);
++          encodedCompleteCallback_ = tempCallback;
++        }
++
++        width_ = frameBuffer->width();
++        height_ = frameBuffer->height();
++        InitEncoderWithSettings(&codec_);
++        RTC_LOG(LS_WARNING) << "Resolution changed to: " << frameBuffer->width()
++                            << "x" << frameBuffer->height();
++      }
++    }
++
++    if (firstFrame_) {
++      firstFrame_ = false;
++      startTime_ = frame.timestamp();
++    }
++
++    auto timestampHns = ((frame.timestamp() - startTime_) / 90) * 1000 * 10;
++    ON_SUCCEEDED(sample->SetSampleTime(timestampHns));
++
++    if (SUCCEEDED(hr)) {
++      auto durationHns = timestampHns - lastTimestampHns_;
++      hr = sample->SetSampleDuration(durationHns);
++    }
++
++    if (SUCCEEDED(hr)) {
++      lastTimestampHns_ = timestampHns;
++
++      // Cache the frame attributes to get them back after the encoding.
++      CachedFrameAttributes frameAttributes;
++      frameAttributes.timestamp = frame.timestamp();
++      frameAttributes.ntpTime = frame.ntp_time_ms();
++      frameAttributes.captureRenderTime = frame.render_time_ms();
++      frameAttributes.frameWidth = frame.width();
++      frameAttributes.frameHeight = frame.height();
++      _sampleAttributeQueue.push(timestampHns, frameAttributes);
++    }
++
++    ON_SUCCEEDED(mediaBuffer->SetCurrentLength(frameBuffer->width() *
++                                               frameBuffer->height() * 3 / 2));
++
++    if (destBuffer != nullptr) {
++      mediaBuffer->Unlock();
++    }
++
++    ON_SUCCEEDED(sample->AddBuffer(mediaBuffer.Get()));
++
++    if (lastFrameDropped_) {
++      lastFrameDropped_ = false;
++      sampleAttributes->SetUINT32(MFSampleExtension_Discontinuity, TRUE);
++    }
++  }
++
++  return sample;
++}
++
++}  // namespace webrtc
+diff --git a/modules/video_coding/codecs/h264/win/encoder/h264_encoder_mf_impl.h b/modules/video_coding/codecs/h264/win/encoder/h264_encoder_mf_impl.h
+new file mode 100644
+index 0000000000..d3d25239c9
+--- /dev/null
++++ b/modules/video_coding/codecs/h264/win/encoder/h264_encoder_mf_impl.h
+@@ -0,0 +1,96 @@
++/*
++ *  Copyright (c) 2020 The WebRTC project authors. All Rights Reserved.
++ *
++ *  Use of this source code is governed by a BSD-style license
++ *  that can be found in the LICENSE file in the root of the source
++ *  tree. An additional intellectual property rights grant can be found
++ *  in the file PATENTS.  All contributing project authors may
++ *  be found in the AUTHORS file in the root of the source tree.
++ *
++ */
++
++#ifndef MODULES_VIDEO_CODING_CODECS_H264_H264_ENCODER_MF_IMPL_H_
++#define MODULES_VIDEO_CODING_CODECS_H264_H264_ENCODER_MF_IMPL_H_
++
++#include <mfidl.h>
++#include <mfreadwrite.h>
++#include <wrl.h>
++#include <vector>
++#include "modules/video_coding/codecs/h264/include/h264.h"
++#include "modules/video_coding/codecs/h264/win/encoder/h264_media_sink.h"
++#include "modules/video_coding/codecs/h264/win/encoder/ih264_encoding_callback.h"
++#include "modules/video_coding/codecs/h264/win/utils/sample_attribute_queue.h"
++
++namespace webrtc {
++
++class H264EncoderMFImpl : public VideoEncoder, IH264EncodingCallback {
++ public:
++ public:
++  explicit H264EncoderMFImpl(const cricket::VideoCodec& codec);
++  ~H264EncoderMFImpl() override;
++
++  int32_t InitEncode(const VideoCodec* codec_settings,
++                     const VideoEncoder::Settings& settings) override;
++  int32_t Release() override;
++  //
++  int32_t RegisterEncodeCompleteCallback(
++      EncodedImageCallback* callback) override;
++  void SetRates(const RateControlParameters& parameters) override;
++
++  // The result of encoding - an EncodedImage and RTPFragmentationHeader - are
++  // passed to the encode complete callback.
++  int32_t Encode(const VideoFrame& frame,
++                 const std::vector<VideoFrameType>* frame_types) override;
++
++  EncoderInfo GetEncoderInfo() const override;
++
++  // === IH264EncodingCallback overrides ===
++  void OnH264Encoded(::Microsoft::WRL::ComPtr<IMFSample> sample) override;
++  //
++
++ private:
++  VideoCodec codec_;
++
++  int InitEncoderWithSettings(const VideoCodec* codec_settings);
++  ::Microsoft::WRL::ComPtr<IMFSample> FromVideoFrame(const VideoFrame& frame);
++
++  rtc::CriticalSection crit_;
++
++  bool inited_{};
++
++  uint32_t currentWidth_;
++  uint32_t currentHeight_;
++  uint32_t currentBitrateBps_;
++  uint32_t currentFps_;
++  UINT32 target_bps_;
++  UINT32 width_;
++  UINT32 height_;
++  UINT32 max_frame_rate_;
++  int64_t lastTimeSettingsChanged_{};
++  ::Microsoft::WRL::ComPtr<H264MediaSink> mediaSink_;
++  ::Microsoft::WRL::ComPtr<IMFAttributes> sinkWriterCreationAttributes_;
++  ::Microsoft::WRL::ComPtr<IMFSinkWriter> sinkWriter_;
++  DWORD streamIndex_{};
++  ::Microsoft::WRL::ComPtr<IMFAttributes> sinkWriterEncoderAttributes_;
++  rtc::CriticalSection callbackCrit_;
++  EncodedImageCallback* encodedCompleteCallback_{};
++  int framePendingCount_;
++  LONGLONG startTime_;
++  LONGLONG lastTimestampHns_;
++  bool firstFrame_;
++  bool lastFrameDropped_;
++
++  struct CachedFrameAttributes {
++    uint32_t timestamp;
++    uint64_t ntpTime;
++    uint64_t captureRenderTime;
++    uint32_t frameWidth;
++    uint32_t frameHeight;
++  };
++  SampleAttributeQueue<CachedFrameAttributes> _sampleAttributeQueue;
++  DWORD frameCount_;
++};
++
++}  // namespace webrtc
++
++#endif  // MODULES_VIDEO_CODING_CODECS_H264_H264_ENCODER_IMPL_MF_H_
+diff --git a/modules/video_coding/codecs/h264/win/encoder/h264_media_sink.cc b/modules/video_coding/codecs/h264/win/encoder/h264_media_sink.cc
+new file mode 100644
+index 0000000000..c7a3880a60
+--- /dev/null
++++ b/modules/video_coding/codecs/h264/win/encoder/h264_media_sink.cc
+@@ -0,0 +1,281 @@
++/*
++*  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
++*
++*  Use of this source code is governed by a BSD-style license
++*  that can be found in the LICENSE file in the root of the source
++*  tree. An additional intellectual property rights grant can be found
++*  in the file PATENTS.  All contributing project authors may
++*  be found in the AUTHORS file in the root of the source tree.
++*/
++
++#include "modules/video_coding/codecs/h264/win/encoder/h264_media_sink.h"
++#include <wrl.h>
++#include <wrl/implements.h>
++
++namespace webrtc {
++
++H264MediaSink::H264MediaSink()
++  : isShutdown_(false) {
++}
++
++
++H264MediaSink::~H264MediaSink() {
++  OutputDebugString(L"H264MediaSink::~H264MediaSink()\r\n");
++}
++
++HRESULT H264MediaSink::RuntimeClassInitialize() {
++  return S_OK;
++}
++
++IFACEMETHODIMP H264MediaSink::GetCharacteristics(DWORD *pdwCharacteristics) {
++  if (pdwCharacteristics == NULL) {
++    return E_INVALIDARG;
++  }
++  AutoLock lock(critSec_);
++
++  HRESULT hr = CheckShutdown();
++
++  if (SUCCEEDED(hr)) {
++    // Rateless sink.
++    *pdwCharacteristics = MEDIASINK_RATELESS;
++  }
++
++  return hr;
++}
++
++IFACEMETHODIMP H264MediaSink::AddStreamSink(
++  DWORD dwStreamSinkIdentifier,
++  IMFMediaType *pMediaType,
++  IMFStreamSink **ppStreamSink) {
++  AutoLock lock(critSec_);
++  HRESULT hr = CheckShutdown();
++
++  if (outputStream_ != nullptr) {
++    hr = MF_E_STREAMSINK_EXISTS;
++  }
++
++  if (SUCCEEDED(hr)) {
++    hr = Microsoft::WRL::MakeAndInitialize<H264StreamSink>(
++      &outputStream_, dwStreamSinkIdentifier, this);
++  }
++
++  if (SUCCEEDED(hr) && pMediaType != nullptr) {
++    hr = outputStream_->SetCurrentMediaType(pMediaType);
++  }
++
++  return hr;
++}
++
++IFACEMETHODIMP H264MediaSink::RemoveStreamSink(DWORD dwStreamSinkIdentifier) {
++  AutoLock lock(critSec_);
++  HRESULT hr = CheckShutdown();
++
++  if (SUCCEEDED(hr)) {
++    if (outputStream_ == nullptr) {
++      hr = E_INVALIDARG;
++    }
++  }
++
++  if (SUCCEEDED(hr)) {
++    DWORD currentSinkId;
++    hr = outputStream_->GetIdentifier(&currentSinkId);
++    if (FAILED(hr) || currentSinkId != dwStreamSinkIdentifier) {
++      hr = E_INVALIDARG;
++    }
++  }
++
++  if (SUCCEEDED(hr)) {
++    hr = outputStream_->Shutdown();
++  }
++
++  outputStream_.Reset();
++
++  return hr;
++}
++
++IFACEMETHODIMP H264MediaSink::GetStreamSinkCount(
++  _Out_ DWORD *pcStreamSinkCount) {
++  if (pcStreamSinkCount == NULL) {
++    return E_INVALIDARG;
++  }
++
++  AutoLock lock(critSec_);
++
++  HRESULT hr = CheckShutdown();
++
++  if (SUCCEEDED(hr)) {
++    *pcStreamSinkCount = outputStream_ == nullptr ? 0 : 1;
++  }
++
++  return hr;
++}
++
++IFACEMETHODIMP H264MediaSink::GetStreamSinkByIndex(
++  DWORD dwIndex,
++  _Outptr_ IMFStreamSink **ppStreamSink) {
++  if (ppStreamSink == NULL) {
++    return E_INVALIDARG;
++  }
++
++  AutoLock lock(critSec_);
++
++  if (dwIndex >= 1) {
++    return MF_E_INVALIDINDEX;
++  }
++
++  HRESULT hr = CheckShutdown();
++
++  if (SUCCEEDED(hr)) {
++    *ppStreamSink = outputStream_.Get();
++    (*ppStreamSink)->AddRef();
++  }
++
++  return hr;
++}
++
++IFACEMETHODIMP H264MediaSink::GetStreamSinkById(
++  DWORD dwStreamSinkIdentifier,
++  IMFStreamSink **ppStreamSink) {
++  if (ppStreamSink == NULL) {
++    return E_INVALIDARG;
++  }
++
++  AutoLock lock(critSec_);
++  HRESULT hr = CheckShutdown();
++  Microsoft::WRL::ComPtr<IMFStreamSink> spResult;
++
++  if (SUCCEEDED(hr)) {
++    if (outputStream_ == nullptr) {
++      hr = MF_E_INVALIDSTREAMNUMBER;
++    }
++  }
++
++  if (SUCCEEDED(hr)) {
++    DWORD currentSinkId;
++    hr = outputStream_->GetIdentifier(&currentSinkId);
++    if (FAILED(hr) || currentSinkId != dwStreamSinkIdentifier) {
++      hr = MF_E_INVALIDSTREAMNUMBER;
++    }
++  }
++
++  if (SUCCEEDED(hr)) {
++    *ppStreamSink = outputStream_.Get();
++    (*ppStreamSink)->AddRef();
++  }
++
++  return hr;
++}
++
++IFACEMETHODIMP H264MediaSink::SetPresentationClock(
++  IMFPresentationClock *pPresentationClock) {
++  AutoLock lock(critSec_);
++
++  HRESULT hr = CheckShutdown();
++
++  if (SUCCEEDED(hr)) {
++    if (spClock_) {
++      hr = spClock_->RemoveClockStateSink(this);
++    }
++  }
++
++  if (SUCCEEDED(hr)) {
++    if (pPresentationClock) {
++      hr = pPresentationClock->AddClockStateSink(this);
++    }
++  }
++
++  if (SUCCEEDED(hr)) {
++    spClock_ = pPresentationClock;
++  }
++
++  return hr;
++}
++
++IFACEMETHODIMP H264MediaSink::GetPresentationClock(
++  IMFPresentationClock **ppPresentationClock) {
++  if (ppPresentationClock == NULL) {
++    return E_INVALIDARG;
++  }
++
++  AutoLock lock(critSec_);
++
++  HRESULT hr = CheckShutdown();
++
++  if (SUCCEEDED(hr)) {
++    if (spClock_ == NULL) {
++      hr = MF_E_NO_CLOCK;
++    } else {
++      *ppPresentationClock = spClock_.Get();
++      (*ppPresentationClock)->AddRef();
++    }
++  }
++
++  return hr;
++}
++
++IFACEMETHODIMP H264MediaSink::Shutdown() {
++  AutoLock lock(critSec_);
++
++  HRESULT hr = CheckShutdown();
++
++  if (SUCCEEDED(hr) && outputStream_ != nullptr) {
++    outputStream_->Shutdown();
++    outputStream_.Reset();
++
++    spClock_.Reset();
++
++    isShutdown_ = true;
++  }
++
++  return S_OK;
++}
++
++IFACEMETHODIMP H264MediaSink::OnClockStart(
++  MFTIME hnsSystemTime,
++  LONGLONG llClockStartOffset) {
++  AutoLock lock(critSec_);
++
++  HRESULT hr = CheckShutdown();
++
++  if (SUCCEEDED(hr)) {
++    hr = outputStream_->Start(llClockStartOffset);
++  }
++
++  return hr;
++}
++
++IFACEMETHODIMP H264MediaSink::OnClockStop(
++  MFTIME hnsSystemTime) {
++  AutoLock lock(critSec_);
++
++  HRESULT hr = CheckShutdown();
++
++  if (SUCCEEDED(hr)) {
++    hr = outputStream_->Stop();
++  }
++
++  return hr;
++}
++
++IFACEMETHODIMP H264MediaSink::OnClockPause(
++  MFTIME hnsSystemTime) {
++  return MF_E_INVALID_STATE_TRANSITION;
++}
++
++IFACEMETHODIMP H264MediaSink::OnClockRestart(
++  MFTIME hnsSystemTime) {
++  return MF_E_INVALID_STATE_TRANSITION;
++}
++
++IFACEMETHODIMP H264MediaSink::OnClockSetRate(
++  /* [in] */ MFTIME hnsSystemTime,
++  /* [in] */ float flRate) {
++  return S_OK;
++}
++
++HRESULT H264MediaSink::RegisterEncodingCallback(
++  IH264EncodingCallback *callback) {
++  return outputStream_->RegisterEncodingCallback(callback);
++}
++
++}  // namespace webrtc
+diff --git a/modules/video_coding/codecs/h264/win/encoder/h264_media_sink.h b/modules/video_coding/codecs/h264/win/encoder/h264_media_sink.h
+new file mode 100644
+index 0000000000..f5a3c3aeba
+--- /dev/null
++++ b/modules/video_coding/codecs/h264/win/encoder/h264_media_sink.h
+@@ -0,0 +1,102 @@
++/*
++*  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
++*
++*  Use of this source code is governed by a BSD-style license
++*  that can be found in the LICENSE file in the root of the source
++*  tree. An additional intellectual property rights grant can be found
++*  in the file PATENTS.  All contributing project authors may
++*  be found in the AUTHORS file in the root of the source tree.
++*/
++
++#ifndef THIRD_PARTY_H264_WINUWP_H264ENCODER_H264MEDIASINK_H_
++#define THIRD_PARTY_H264_WINUWP_H264ENCODER_H264MEDIASINK_H_
++
++#include <Mferror.h>
++#include <mfidl.h>
++#include <windows.foundation.h>
++#include <windows.media.h>
++#include <windows.media.mediaproperties.h>
++#include <wrl.h>
++
++#include "../Utils/crit_sec.h"
++#include "ih264_encoding_callback.h"
++#include "h264_stream_sink.h"
++
++namespace webrtc {
++
++class H264StreamSink;
++class H264MediaSink : public Microsoft::WRL::RuntimeClass<
++  Microsoft::WRL::RuntimeClassFlags<
++  Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
++  ABI::Windows::Media::IMediaExtension,
++  Microsoft::WRL::FtmBase,
++  IMFMediaSink,
++  IMFClockStateSink> {
++  InspectableClass(L"H264MediaSink", BaseTrust)
++
++ public:
++  H264MediaSink();
++  virtual ~H264MediaSink();
++
++  HRESULT RuntimeClassInitialize();
++
++  // IMediaExtension
++  IFACEMETHOD(SetProperties)
++    (ABI::Windows::Foundation::Collections::IPropertySet
++      *pConfiguration) {
++    return S_OK;
++  }
++
++  // IMFMediaSink methods
++  IFACEMETHOD(GetCharacteristics) (DWORD *pdwCharacteristics);
++
++  IFACEMETHOD(AddStreamSink)(
++    /* [in] */ DWORD dwStreamSinkIdentifier,
++    /* [in] */ IMFMediaType *pMediaType,
++    /* [out] */ IMFStreamSink **ppStreamSink);
++
++  IFACEMETHOD(RemoveStreamSink) (DWORD dwStreamSinkIdentifier);
++  IFACEMETHOD(GetStreamSinkCount) (_Out_ DWORD *pcStreamSinkCount);
++  IFACEMETHOD(GetStreamSinkByIndex)
++    (DWORD dwIndex, _Outptr_ IMFStreamSink **ppStreamSink);
++  IFACEMETHOD(GetStreamSinkById)
++    (DWORD dwIdentifier, IMFStreamSink **ppStreamSink);
++  IFACEMETHOD(SetPresentationClock)
++    (IMFPresentationClock *pPresentationClock);
++  IFACEMETHOD(GetPresentationClock)
++    (IMFPresentationClock **ppPresentationClock);
++  IFACEMETHOD(Shutdown) ();
++
++  // IMFClockStateSink methods
++  IFACEMETHOD(OnClockStart)
++    (MFTIME hnsSystemTime, LONGLONG llClockStartOffset);
++  IFACEMETHOD(OnClockStop) (MFTIME hnsSystemTime);
++  IFACEMETHOD(OnClockPause) (MFTIME hnsSystemTime);
++  IFACEMETHOD(OnClockRestart) (MFTIME hnsSystemTime);
++  IFACEMETHOD(OnClockSetRate) (MFTIME hnsSystemTime, float flRate);
++
++  HRESULT RegisterEncodingCallback(IH264EncodingCallback *callback);
++
++ private:
++  void HandleError(HRESULT hr);
++
++  HRESULT CheckShutdown() const {
++    if (isShutdown_) {
++      return MF_E_SHUTDOWN;
++    } else {
++      return S_OK;
++    }
++  }
++
++ private:
++  CritSec critSec_;
++
++  bool isShutdown_;
++
++  Microsoft::WRL::ComPtr<IMFPresentationClock> spClock_;
++  Microsoft::WRL::ComPtr<H264StreamSink> outputStream_;
++};
++
++}  // namespace webrtc
++
++#endif  // THIRD_PARTY_H264_WINUWP_H264ENCODER_H264MEDIASINK_H_
+diff --git a/modules/video_coding/codecs/h264/win/encoder/h264_stream_sink.cc b/modules/video_coding/codecs/h264/win/encoder/h264_stream_sink.cc
+new file mode 100644
+index 0000000000..61d12c2cfe
+--- /dev/null
++++ b/modules/video_coding/codecs/h264/win/encoder/h264_stream_sink.cc
+@@ -0,0 +1,605 @@
++/*
++*  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
++*
++*  Use of this source code is governed by a BSD-style license
++*  that can be found in the LICENSE file in the root of the source
++*  tree. An additional intellectual property rights grant can be found
++*  in the file PATENTS.  All contributing project authors may
++*  be found in the AUTHORS file in the root of the source tree.
++*/
++
++#include "modules/video_coding/codecs/h264/win/encoder/h264_stream_sink.h"
++
++#include <Windows.h>
++#include <mfapi.h>
++#include <mfidl.h>
++#include "../utils/utils.h"
++#include "rtc_base/logging.h"
++
++namespace webrtc {
++
++class H264MediaSink;
++
++H264StreamSink::H264StreamSink()
++  : dwIdentifier_((DWORD)-1)
++  , state_(State_TypeNotSet)
++  , isShutdown_(false)
++  , workQueueId_(0)
++  , workQueueCB_(this, &H264StreamSink::OnDispatchWorkItem) {
++}
++
++H264StreamSink::~H264StreamSink() {
++  OutputDebugString(L"H264StreamSink::~H264StreamSink()\r\n");
++}
++
++HRESULT H264StreamSink::RuntimeClassInitialize(
++  DWORD dwIdentifier, H264MediaSink *pParent) {
++  HRESULT hr = S_OK;
++
++  hr = MFCreateEventQueue(&spEventQueue_);
++
++  // Allocate a new work queue for async operations.
++  if (SUCCEEDED(hr)) {
++    hr = MFAllocateSerialWorkQueue(MFASYNC_CALLBACK_QUEUE_STANDARD,
++      &workQueueId_);
++  }
++
++  if (SUCCEEDED(hr)) {
++    spSink_ = reinterpret_cast<IMFMediaSink*>(pParent);
++    dwIdentifier_ = dwIdentifier;
++  }
++
++  return hr;
++}
++
++IFACEMETHODIMP H264StreamSink::BeginGetEvent(
++  IMFAsyncCallback *pCallback, IUnknown *punkState) {
++  HRESULT hr = S_OK;
++
++  AutoLock lock(critSec_);
++
++  hr = CheckShutdown();
++
++  if (SUCCEEDED(hr)) {
++    hr = spEventQueue_->BeginGetEvent(pCallback, punkState);
++  }
++
++  return hr;
++}
++
++IFACEMETHODIMP H264StreamSink::EndGetEvent(
++  IMFAsyncResult *pResult, IMFMediaEvent **ppEvent) {
++  HRESULT hr = S_OK;
++
++  AutoLock lock(critSec_);
++
++  hr = CheckShutdown();
++
++  if (SUCCEEDED(hr)) {
++    hr = spEventQueue_->EndGetEvent(pResult, ppEvent);
++  }
++
++  return hr;
++}
++
++IFACEMETHODIMP H264StreamSink::GetEvent(
++  DWORD dwFlags, IMFMediaEvent **ppEvent) {
++  // NOTE:
++  // GetEvent can block indefinitely, so we don't hold the lock.
++  // This requires some juggling with the event queue pointer.
++
++  HRESULT hr = S_OK;
++
++  Microsoft::WRL::ComPtr<IMFMediaEventQueue> spQueue;
++  {
++    AutoLock lock(critSec_);
++
++    hr = CheckShutdown();
++
++    if (SUCCEEDED(hr)) {
++      spQueue = spEventQueue_;
++    }
++  }
++
++  if (SUCCEEDED(hr)) {
++    hr = spQueue->GetEvent(dwFlags, ppEvent);
++  }
++
++  return hr;
++}
++
++IFACEMETHODIMP H264StreamSink::QueueEvent(
++  MediaEventType met, REFGUID guidExtendedType,
++  HRESULT hrStatus, PROPVARIANT const *pvValue) {
++  HRESULT hr = S_OK;
++
++  AutoLock lock(critSec_);
++
++  hr = CheckShutdown();
++
++  if (SUCCEEDED(hr)) {
++    hr = spEventQueue_->QueueEventParamVar(met, guidExtendedType,
++      hrStatus, pvValue);
++  }
++
++  return hr;
++}
++
++/// IMFStreamSink methods
++IFACEMETHODIMP H264StreamSink::GetMediaSink(IMFMediaSink **ppMediaSink) {
++  if (ppMediaSink == nullptr) {
++    return E_INVALIDARG;
++  }
++
++  AutoLock lock(critSec_);
++
++  HRESULT hr = CheckShutdown();
++
++  if (SUCCEEDED(hr)) {
++    *ppMediaSink = spSink_.Get();
++    (*ppMediaSink)->AddRef();
++  }
++
++  return hr;
++}
++
++IFACEMETHODIMP H264StreamSink::GetIdentifier(DWORD *pdwIdentifier) {
++  if (pdwIdentifier == nullptr) {
++    return E_INVALIDARG;
++  }
++
++  AutoLock lock(critSec_);
++
++  HRESULT hr = CheckShutdown();
++
++  if (SUCCEEDED(hr)) {
++    *pdwIdentifier = dwIdentifier_;
++  }
++
++  return hr;
++}
++
++IFACEMETHODIMP H264StreamSink::GetMediaTypeHandler(
++  IMFMediaTypeHandler **ppHandler) {
++  if (ppHandler == nullptr) {
++    return E_INVALIDARG;
++  }
++
++  AutoLock lock(critSec_);
++
++  HRESULT hr = CheckShutdown();
++
++  // This stream object acts as its own type handler, so we QI ourselves.
++  if (SUCCEEDED(hr)) {
++    hr = QueryInterface(IID_IMFMediaTypeHandler, (void**)ppHandler);
++  }
++
++  return hr;
++}
++
++IFACEMETHODIMP H264StreamSink::ProcessSample(IMFSample *pSample) {
++  if (pSample == nullptr) {
++    return E_INVALIDARG;
++  }
++
++  HRESULT hr = S_OK;
++
++  AutoLock lock(critSec_);
++
++  hr = CheckShutdown();
++
++  if (SUCCEEDED(hr)) {
++    hr = ValidateOperation(OpProcessSample);
++  }
++
++  if (SUCCEEDED(hr)) {
++    sampleQueue_.push_back(pSample);
++
++    hr = QueueAsyncOperation(OpProcessSample);
++  }
++
++  return hr;
++}
++
++IFACEMETHODIMP H264StreamSink::PlaceMarker(
++  MFSTREAMSINK_MARKER_TYPE eMarkerType,
++  const PROPVARIANT *pvarMarkerValue,
++  const PROPVARIANT *pvarContextValue) {
++  AutoLock lock(critSec_);
++  HRESULT hr = S_OK;
++  hr = CheckShutdown();
++  if (SUCCEEDED(hr)) {
++    hr = QueueAsyncOperation(OpPlaceMarker, pvarContextValue);
++  }
++  return hr;
++}
++
++IFACEMETHODIMP H264StreamSink::Flush() {
++  AutoLock lock(critSec_);
++  HRESULT hr = CheckShutdown();
++
++  if (SUCCEEDED(hr)) {
++    DropSamplesFromQueue();
++  }
++
++  return hr;
++}
++
++/// IMFMediaTypeHandler methods
++
++IFACEMETHODIMP H264StreamSink::IsMediaTypeSupported(
++  /* [in] */ IMFMediaType *pMediaType,
++  /* [out] */ IMFMediaType **ppMediaType) {
++  if (pMediaType == nullptr) {
++    return E_INVALIDARG;
++  }
++
++  AutoLock lock(critSec_);
++
++  GUID majorType = GUID_NULL;
++
++  HRESULT hr = CheckShutdown();
++
++  if (SUCCEEDED(hr)) {
++    hr = pMediaType->GetGUID(MF_MT_MAJOR_TYPE, &majorType);
++  }
++
++  if (SUCCEEDED(hr)) {
++    if (majorType != MFMediaType_Video && majorType != MFMediaType_Audio) {
++      hr = MF_E_INVALIDTYPE;
++    }
++  }
++
++  // Don't support changing subtype.
++  if (SUCCEEDED(hr) && spCurrentType_ != nullptr) {
++    GUID guiNewSubtype;
++    if (FAILED(pMediaType->GetGUID(MF_MT_SUBTYPE, &guiNewSubtype)) ||
++      guiNewSubtype != guidCurrentSubtype_) {
++      hr = MF_E_INVALIDTYPE;
++    }
++  }
++
++  if (ppMediaType) {
++    *ppMediaType = nullptr;
++  }
++
++  return hr;
++}
++
++IFACEMETHODIMP H264StreamSink::GetMediaTypeCount(DWORD *pdwTypeCount) {
++  if (pdwTypeCount == nullptr) {
++    return E_INVALIDARG;
++  }
++
++  AutoLock lock(critSec_);
++
++  HRESULT hr = CheckShutdown();
++
++  if (SUCCEEDED(hr)) {
++    *pdwTypeCount = 1;
++  }
++
++  return hr;
++}
++
++IFACEMETHODIMP H264StreamSink::GetMediaTypeByIndex(
++  /* [in] */ DWORD dwIndex,
++  /* [out] */ IMFMediaType **ppType) {
++  if (ppType == nullptr) {
++    return E_INVALIDARG;
++  }
++
++  AutoLock lock(critSec_);
++
++  HRESULT hr = CheckShutdown();
++
++  if (dwIndex > 0) {
++    hr = MF_E_NO_MORE_TYPES;
++  } else {
++    *ppType = spCurrentType_.Get();
++    if (*ppType != nullptr) {
++      (*ppType)->AddRef();
++    }
++  }
++
++  return hr;
++}
++
++IFACEMETHODIMP H264StreamSink::SetCurrentMediaType(
++  IMFMediaType *pMediaType) {
++  HRESULT hr = S_OK;
++  if (pMediaType == nullptr) {
++    hr = E_INVALIDARG;
++  }
++
++  AutoLock lock(critSec_);
++
++  ON_SUCCEEDED(CheckShutdown());
++
++  ON_SUCCEEDED(ValidateOperation(OpSetMediaType));
++
++  // We set media type already
++  if (state_ >= State_Ready) {
++    ON_SUCCEEDED(IsMediaTypeSupported(pMediaType, nullptr));
++  }
++
++  ON_SUCCEEDED(MFCreateMediaType(spCurrentType_.ReleaseAndGetAddressOf()));
++  ON_SUCCEEDED(pMediaType->CopyAllItems(spCurrentType_.Get()));
++  ON_SUCCEEDED(spCurrentType_->GetGUID(MF_MT_SUBTYPE, &guidCurrentSubtype_));
++  if (SUCCEEDED(hr)) {
++    if (state_ < State_Ready) {
++      state_ = State_Ready;
++    } else if (state_ > State_Ready) {
++      if (SUCCEEDED(hr)) {
++        ProcessFormatChange();
++      }
++    }
++  }
++  return hr;
++}
++
++IFACEMETHODIMP H264StreamSink::GetCurrentMediaType(
++  IMFMediaType **ppMediaType) {
++  if (ppMediaType == nullptr) {
++    return E_INVALIDARG;
++  }
++
++  AutoLock lock(critSec_);
++
++  HRESULT hr = CheckShutdown();
++
++  if (SUCCEEDED(hr)) {
++    if (spCurrentType_ == nullptr) {
++      hr = MF_E_NOT_INITIALIZED;
++    }
++  }
++
++  if (SUCCEEDED(hr)) {
++    *ppMediaType = spCurrentType_.Get();
++    (*ppMediaType)->AddRef();
++  }
++
++  return hr;
++}
++
++IFACEMETHODIMP H264StreamSink::GetMajorType(GUID *pguidMajorType) {
++  if (pguidMajorType == nullptr) {
++    return E_INVALIDARG;
++  }
++
++  if (!spCurrentType_) {
++    return MF_E_NOT_INITIALIZED;
++  }
++
++  *pguidMajorType = MFMediaType_Video;
++
++  return S_OK;
++}
++
++HRESULT H264StreamSink::Start(MFTIME start) {
++  AutoLock lock(critSec_);
++
++  HRESULT hr = S_OK;
++
++  hr = ValidateOperation(OpStart);
++
++  if (SUCCEEDED(hr)) {
++    state_ = State_Started;
++    hr = QueueAsyncOperation(OpStart);
++  }
++
++  return hr;
++}
++
++HRESULT H264StreamSink::Stop() {
++  AutoLock lock(critSec_);
++
++  HRESULT hr = S_OK;
++
++  hr = ValidateOperation(OpStop);
++
++  if (SUCCEEDED(hr)) {
++    state_ = State_Stopped;
++    hr = QueueAsyncOperation(OpStop);
++  }
++
++  return hr;
++}
++
++BOOL H264StreamSink::ValidStateMatrix
++  [State::State_Count][StreamOperation::Op_Count] = {
++    // States:    Operations:
++    //            SetType Start Stop Sample
++    /* NotSet */  {TRUE, FALSE, FALSE, FALSE},
++    /* Ready */   {TRUE,  TRUE,  TRUE, FALSE},
++    /* Start */   {TRUE,  TRUE,  TRUE,  TRUE},
++    /* Stop */    {TRUE,  TRUE,  TRUE, FALSE}
++};
++
++HRESULT H264StreamSink::ValidateOperation(StreamOperation op) {
++  if (ValidStateMatrix[state_][op]) {
++    return S_OK;
++  } else if (state_ == State_TypeNotSet) {
++    return MF_E_NOT_INITIALIZED;
++  } else {
++    return MF_E_INVALIDREQUEST;
++  }
++}
++
++HRESULT H264StreamSink::Shutdown() {
++  AutoLock lock(critSec_);
++
++  if (!isShutdown_) {
++    if (spEventQueue_) {
++      spEventQueue_->Shutdown();
++    }
++
++    MFUnlockWorkQueue(workQueueId_);
++
++    sampleQueue_.clear();
++
++    spSink_.Reset();
++    spEventQueue_.Reset();
++    spCurrentType_.Reset();
++
++    encodingCallback_ = nullptr;
++
++    isShutdown_ = true;
++  }
++
++  return S_OK;
++}
++
++HRESULT H264StreamSink::QueueAsyncOperation(StreamOperation op, const PROPVARIANT* propVariant) {
++  HRESULT hr = S_OK;
++  Microsoft::WRL::ComPtr<IUnknown> spOp;
++  hr = Microsoft::WRL::MakeAndInitialize<AsyncStreamSinkOperation>(&spOp, op, propVariant);
++
++  if (SUCCEEDED(hr)) {
++    hr = MFPutWorkItem2(workQueueId_, 0, &workQueueCB_, spOp.Get());
++  }
++
++  return hr;
++}
++
++HRESULT H264StreamSink::OnDispatchWorkItem(IMFAsyncResult *pAsyncResult) {
++  HRESULT hr = S_OK;
++  auto sample = ComPtr<IMFSample>();
++
++  // Scope the AutoLock
++  {
++    AutoLock lock(critSec_);
++    Microsoft::WRL::ComPtr<IUnknown> spState;
++
++    hr = pAsyncResult->GetState(&spState);
++
++    if (SUCCEEDED(hr)) {
++      ComPtr<IAsyncStreamSinkOperation> pOp;
++      spState.As(&pOp);
++      StreamOperation op;
++      pOp->GetOp(&op);
++
++      switch (op) {
++      case OpStart:
++        hr = QueueEvent(MEStreamSinkStarted, GUID_NULL, S_OK, nullptr);
++
++        if (SUCCEEDED(hr)) {
++          sample = ProcessSamplesFromQueue();
++          if (sample == nullptr) {
++            hr = QueueEvent(MEStreamSinkRequestSample,
++              GUID_NULL, S_OK, nullptr);
++          }
++        }
++        break;
++
++      case OpStop:
++        DropSamplesFromQueue();
++
++        hr = QueueEvent(MEStreamSinkStopped, GUID_NULL, S_OK, nullptr);
++        break;
++
++      case OpProcessSample:
++        hr = QueueEvent(MEStreamSinkRequestSample, GUID_NULL, S_OK, nullptr);
++        if (SUCCEEDED(hr)) {
++          sample = ProcessSamplesFromQueue();
++        }
++        break;
++
++      case OpPlaceMarker: {
++          PROPVARIANT propVariant;
++          PropVariantInit(&propVariant);
++          if (SUCCEEDED(pOp->GetPropVariant(&propVariant))) {
++            hr = QueueEvent(MEStreamSinkMarker, GUID_NULL, S_OK, &propVariant);
++          }
++          break;
++        }
++
++      case OpSetMediaType:
++        hr = QueueEvent(MEStreamSinkFormatChanged, GUID_NULL, S_OK, nullptr);
++        break;
++
++      case Op_Count: break;
++      }
++    }
++  }
++
++  if (SUCCEEDED(hr) && sample != nullptr) {
++    AutoLock lock(cbCritSec_);
++    if (encodingCallback_ != nullptr) {
++      encodingCallback_->OnH264Encoded(sample);
++    }
++  }
++
++  return hr;
++}
++
++bool H264StreamSink::DropSamplesFromQueue() {
++  sampleQueue_.clear();
++
++  return true;
++}
++
++ComPtr<IMFSample> H264StreamSink::ProcessSamplesFromQueue() {
++  Microsoft::WRL::ComPtr<IUnknown> spunkSample;
++  auto sample = ComPtr<IMFSample>();
++
++  if (!sampleQueue_.empty()) {
++    spunkSample = sampleQueue_.front();
++    sampleQueue_.pop_front();
++    spunkSample.As<IMFSample>(&sample);
++  }
++
++  return sample;
++}
++
++void H264StreamSink::ProcessFormatChange() {
++  HRESULT hr = S_OK;
++
++  hr = QueueAsyncOperation(OpSetMediaType);
++}
++
++void H264StreamSink::HandleError(HRESULT hr) {
++  if (!isShutdown_) {
++    QueueEvent(MEError, GUID_NULL, hr, nullptr);
++  }
++}
++
++
++HRESULT AsyncStreamSinkOperation::RuntimeClassInitialize(
++  StreamOperation op, const PROPVARIANT* propVariant) {
++  HRESULT hr = S_OK;
++  m_op = op;
++  if (propVariant != nullptr) {
++    PropVariantCopy(&m_propVariant, propVariant);
++  }
++  else {
++    PropVariantInit(&m_propVariant);
++  }
++  return hr;
++}
++
++AsyncStreamSinkOperation::~AsyncStreamSinkOperation() {
++}
++
++HRESULT AsyncStreamSinkOperation::GetOp(StreamOperation* op) {
++  if (op == nullptr)
++    return E_INVALIDARG;
++  *op = m_op;
++  return S_OK;
++}
++
++HRESULT AsyncStreamSinkOperation::GetPropVariant(PROPVARIANT* propVariant) {
++  if (propVariant == nullptr)
++    return E_INVALIDARG;
++  PropVariantCopy(propVariant, &m_propVariant);
++  return S_OK;
++}
++
++HRESULT H264StreamSink::RegisterEncodingCallback(
++  IH264EncodingCallback *callback) {
++  AutoLock lock(cbCritSec_);
++  encodingCallback_ = callback;
++  return S_OK;
++}
++
++}  // namespace webrtc
+diff --git a/modules/video_coding/codecs/h264/win/encoder/h264_stream_sink.h b/modules/video_coding/codecs/h264/win/encoder/h264_stream_sink.h
+new file mode 100644
+index 0000000000..6a7950068a
+--- /dev/null
++++ b/modules/video_coding/codecs/h264/win/encoder/h264_stream_sink.h
+@@ -0,0 +1,170 @@
++/*
++*  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
++*
++*  Use of this source code is governed by a BSD-style license
++*  that can be found in the LICENSE file in the root of the source
++*  tree. An additional intellectual property rights grant can be found
++*  in the file PATENTS.  All contributing project authors may
++*  be found in the AUTHORS file in the root of the source tree.
++*/
++
++#ifndef THIRD_PARTY_H264_WINUWP_H264ENCODER_H264STREAMSINK_H_
++#define THIRD_PARTY_H264_WINUWP_H264ENCODER_H264STREAMSINK_H_
++
++#include <mfidl.h>
++#include <Mferror.h>
++#include <list>
++
++#include "../Utils/async.h"
++#include "../Utils/crit_sec.h"
++#include "ih264_encoding_callback.h"
++
++using Microsoft::WRL::ComPtr;
++
++namespace webrtc {
++
++enum State {
++  State_TypeNotSet = 0,    // No media type is set
++  State_Ready,             // Media type is set, Start has never been called.
++  State_Started,
++  State_Stopped,
++  State_Count              // Number of states
++};
++
++enum StreamOperation {
++  OpSetMediaType = 0,
++  OpStart,
++  OpStop,
++  OpProcessSample,
++  OpPlaceMarker,
++  Op_Count
++};
++
++class H264MediaSink;
++
++class DECLSPEC_UUID("4b35435f-44ae-44a0-9ba0-b84f9f4a9c19")
++  IAsyncStreamSinkOperation : public IUnknown {
++ public:
++  STDMETHOD(GetOp)(StreamOperation* op) PURE;
++  STDMETHOD(GetPropVariant)(PROPVARIANT* propVariant) PURE;
++};
++
++class DECLSPEC_UUID("0c89c2e1-79bb-4ad7-a34f-cc006225f8e1")
++  AsyncStreamSinkOperation
++  : public Microsoft::WRL::RuntimeClass<
++  Microsoft::WRL::RuntimeClassFlags<
++  Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
++  IAsyncStreamSinkOperation> {
++  InspectableClass(L"AsyncStreamSinkOperation", BaseTrust)
++ public:
++  HRESULT RuntimeClassInitialize(StreamOperation op, const PROPVARIANT* propVariant);
++  virtual ~AsyncStreamSinkOperation();
++
++  IFACEMETHOD(GetOp) (StreamOperation* op);
++  IFACEMETHOD(GetPropVariant)(PROPVARIANT* propVariant);
++
++ private:
++  PROPVARIANT m_propVariant;
++  StreamOperation m_op;
++};
++
++class H264StreamSink : public Microsoft::WRL::RuntimeClass<
++  Microsoft::WRL::RuntimeClassFlags<
++    Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
++  IMFStreamSink,
++  IMFMediaEventGenerator,
++  IMFMediaTypeHandler> {
++  InspectableClass(L"H264StreamSink", BaseTrust)
++
++ public:
++  HRESULT RuntimeClassInitialize(DWORD dwIdentifier, H264MediaSink *pParent);
++
++  // IMFMediaEventGenerator
++  IFACEMETHOD(BeginGetEvent)(IMFAsyncCallback *pCallback, IUnknown *punkState);
++  IFACEMETHOD(EndGetEvent) (IMFAsyncResult *pResult, IMFMediaEvent **ppEvent);
++  IFACEMETHOD(GetEvent) (DWORD dwFlags, IMFMediaEvent **ppEvent);
++  IFACEMETHOD(QueueEvent) (MediaEventType met, REFGUID guidExtendedType,
++    HRESULT hrStatus, PROPVARIANT const *pvValue);
++
++  // IMFStreamSink
++  IFACEMETHOD(GetMediaSink) (IMFMediaSink **ppMediaSink);
++  IFACEMETHOD(GetIdentifier) (DWORD *pdwIdentifier);
++  IFACEMETHOD(GetMediaTypeHandler) (IMFMediaTypeHandler **ppHandler);
++  IFACEMETHOD(ProcessSample) (IMFSample *pSample);
++
++  IFACEMETHOD(PlaceMarker) (
++    /* [in] */ MFSTREAMSINK_MARKER_TYPE eMarkerType,
++    /* [in] */ PROPVARIANT const *pvarMarkerValue,
++    /* [in] */ PROPVARIANT const *pvarContextValue);
++
++  IFACEMETHOD(Flush)();
++
++  // IMFMediaTypeHandler
++  IFACEMETHOD(IsMediaTypeSupported) (IMFMediaType *pMediaType,
++    IMFMediaType **ppMediaType);
++  IFACEMETHOD(GetMediaTypeCount) (DWORD *pdwTypeCount);
++  IFACEMETHOD(GetMediaTypeByIndex) (DWORD dwIndex, IMFMediaType **ppType);
++  IFACEMETHOD(SetCurrentMediaType) (IMFMediaType *pMediaType);
++  IFACEMETHOD(GetCurrentMediaType) (IMFMediaType **ppMediaType);
++  IFACEMETHOD(GetMajorType) (GUID *pguidMajorType);
++
++  // ValidStateMatrix: Defines a look-up table that says which operations
++  // are valid from which states.
++  static BOOL ValidStateMatrix[State_Count][Op_Count];
++
++  HRESULT RegisterEncodingCallback(IH264EncodingCallback *callback);
++
++  H264StreamSink();
++  virtual ~H264StreamSink();
++
++  HRESULT CheckShutdown() const {
++    if (isShutdown_) {
++      return MF_E_SHUTDOWN;
++    } else {
++      return S_OK;
++    }
++  }
++
++
++  HRESULT     Start(MFTIME start);
++  HRESULT     Stop();
++  HRESULT     Shutdown();
++
++ private:
++  HRESULT     ValidateOperation(StreamOperation op);
++
++  HRESULT     QueueAsyncOperation(StreamOperation op, const PROPVARIANT* propVariant = nullptr);
++
++  HRESULT     OnDispatchWorkItem(IMFAsyncResult *pAsyncResult);
++
++  bool        DropSamplesFromQueue();
++  ComPtr<IMFSample> ProcessSamplesFromQueue();
++  void        ProcessFormatChange();
++
++  void        HandleError(HRESULT hr);
++
++ private:
++  CritSec                     critSec_;
++  CritSec                     cbCritSec_;
++
++  DWORD                       dwIdentifier_;
++  State                       state_;
++  bool                        isShutdown_;
++  GUID                        guidCurrentSubtype_;
++
++  DWORD                       workQueueId_;
++
++  ComPtr<IMFMediaSink>        spSink_;
++  ComPtr<IMFMediaEventQueue>  spEventQueue_;
++  ComPtr<IMFMediaType>        spCurrentType_;
++
++  std::list<ComPtr<IUnknown>> sampleQueue_;
++
++  AsyncCallback<H264StreamSink>               workQueueCB_;
++
++  IH264EncodingCallback*                      encodingCallback_;
++};
++
++}  // namespace webrtc
++
++#endif  // THIRD_PARTY_H264_WINUWP_H264ENCODER_H264STREAMSINK_H_
+diff --git a/modules/video_coding/codecs/h264/win/encoder/ih264_encoding_callback.h b/modules/video_coding/codecs/h264/win/encoder/ih264_encoding_callback.h
+new file mode 100644
+index 0000000000..b1e51b3324
+--- /dev/null
++++ b/modules/video_coding/codecs/h264/win/encoder/ih264_encoding_callback.h
+@@ -0,0 +1,26 @@
++/*
++*  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
++*
++*  Use of this source code is governed by a BSD-style license
++*  that can be found in the LICENSE file in the root of the source
++*  tree. An additional intellectual property rights grant can be found
++*  in the file PATENTS.  All contributing project authors may
++*  be found in the AUTHORS file in the root of the source tree.
++*/
++
++#ifndef THIRD_PARTY_H264_WINUWP_H264ENCODER_IH264ENCODINGCALLBACK_H_
++#define THIRD_PARTY_H264_WINUWP_H264ENCODER_IH264ENCODINGCALLBACK_H_
++
++#include <wrl\implements.h>
++
++
++namespace webrtc {
++
++interface IH264EncodingCallback {
++    virtual void OnH264Encoded(Microsoft::WRL::ComPtr<IMFSample> sample) = 0;
++};
++
++}  // namespace webrtc
++
++#endif  // THIRD_PARTY_H264_WINUWP_H264ENCODER_IH264ENCODINGCALLBACK_H_
++
+diff --git a/modules/video_coding/codecs/h264/win/h264_mf_factory.cc b/modules/video_coding/codecs/h264/win/h264_mf_factory.cc
+new file mode 100644
+index 0000000000..b398c165b5
+--- /dev/null
++++ b/modules/video_coding/codecs/h264/win/h264_mf_factory.cc
+@@ -0,0 +1,62 @@
++/*
++ *  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
++ *
++ *  Use of this source code is governed by a BSD-style license
++ *  that can be found in the LICENSE file in the root of the source
++ *  tree. An additional intellectual property rights grant can be found
++ *  in the file PATENTS.  All contributing project authors may
++ *  be found in the AUTHORS file in the root of the source tree.
++ */
++
++#include "modules/video_coding/codecs/h264/win/h264_mf_factory.h"
++
++#include <vector>
++
++#include "api/video_codecs/sdp_video_format.h"
++#include "common_types.h"
++#include "media/base/h264_profile_level_id.h"
++#include "modules/video_coding/codecs/h264/win/encoder/h264_encoder_mf_impl.h"
++
++namespace webrtc {
++
++SdpVideoFormat CreateH264Format(H264::Profile profile,
++                                H264::Level level,
++                                const std::string& packetization_mode) {
++  const absl::optional<std::string> profile_string =
++      H264::ProfileLevelIdToString(H264::ProfileLevelId(profile, level));
++  RTC_CHECK(profile_string);
++  return SdpVideoFormat(
++      cricket::kH264CodecName,
++      {{cricket::kH264FmtpProfileLevelId, *profile_string},
++       {cricket::kH264FmtpLevelAsymmetryAllowed, "1"},
++       {cricket::kH264FmtpPacketizationMode, packetization_mode}});
++}
++
++H264MFEncoderFactory::H264MFEncoderFactory() {}
++
++std::vector<SdpVideoFormat> H264MFEncoderFactory::GetSupportedFormats() const {
++  return {
++      CreateH264Format(H264::kProfileBaseline, H264::kLevel3_1, "1"),
++      CreateH264Format(H264::kProfileBaseline, H264::kLevel3_1, "0"),
++      CreateH264Format(H264::kProfileConstrainedBaseline, H264::kLevel3_1, "1"),
++      CreateH264Format(H264::kProfileConstrainedBaseline, H264::kLevel3_1,
++                       "0")};
++}
++
++VideoEncoderFactory::CodecInfo H264MFEncoderFactory::QueryVideoEncoder(
++    const SdpVideoFormat& format) const {
++  VideoEncoderFactory::CodecInfo codec_info;
++
++  codec_info.has_internal_source = false;
++  codec_info.is_hardware_accelerated = true;
++
++  return codec_info;
++}
++
++std::unique_ptr<VideoEncoder> H264MFEncoderFactory::CreateVideoEncoder(
++    const SdpVideoFormat& format) {
++  cricket::VideoCodec codec{std::string(cricket::kH264CodecName)};
++  return std::make_unique<H264EncoderMFImpl>(codec);
++}
++
++}  // namespace webrtc
+diff --git a/modules/video_coding/codecs/h264/win/h264_mf_factory.h b/modules/video_coding/codecs/h264/win/h264_mf_factory.h
+new file mode 100644
+index 0000000000..4d6f02d538
+--- /dev/null
++++ b/modules/video_coding/codecs/h264/win/h264_mf_factory.h
+@@ -0,0 +1,35 @@
++/*
++ *  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
++ *
++ *  Use of this source code is governed by a BSD-style license
++ *  that can be found in the LICENSE file in the root of the source
++ *  tree. An additional intellectual property rights grant can be found
++ *  in the file PATENTS.  All contributing project authors may
++ *  be found in the AUTHORS file in the root of the source tree.
++ */
++
++#ifndef MODULES_VIDEO_CODING_CODECS_H264_WIN_H264_MF_FACTORY_H_
++#define MODULES_VIDEO_CODING_CODECS_H264_WIN_H264_MF_FACTORY_H_
++
++#include <string>
++
++#include "api/video_codecs/video_encoder_factory.h"
++
++namespace webrtc {
++
++class H264MFEncoderFactory : public VideoEncoderFactory {
++ public:
++  H264MFEncoderFactory();
++
++  std::vector<SdpVideoFormat> GetSupportedFormats() const override;
++
++  VideoEncoderFactory::CodecInfo QueryVideoEncoder(
++      const SdpVideoFormat& format) const override;
++
++  std::unique_ptr<VideoEncoder> CreateVideoEncoder(
++      const SdpVideoFormat& format) override;
++};
++
++}  // namespace webrtc
++
++#endif  // MODULES_VIDEO_CODING_CODECS_H264_WIN_H264_MF_FACTORY_H_
+diff --git a/modules/video_coding/codecs/h264/win/utils/async.h b/modules/video_coding/codecs/h264/win/utils/async.h
+new file mode 100644
+index 0000000000..febd350e80
+--- /dev/null
++++ b/modules/video_coding/codecs/h264/win/utils/async.h
+@@ -0,0 +1,66 @@
++/*
++ *  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
++ *
++ *  Use of this source code is governed by a BSD-style license
++ *  that can be found in the LICENSE file in the root of the source
++ *  tree. An additional intellectual property rights grant can be found
++ *  in the file PATENTS.  All contributing project authors may
++ *  be found in the AUTHORS file in the root of the source tree.
++ */
++
++#ifndef MODULES_VIDEO_CODING_CODECS_H264_WIN_UTILS_ASYNC_H_
++#define MODULES_VIDEO_CODING_CODECS_H264_WIN_UTILS_ASYNC_H_
++
++#include <mfidl.h>
++
++template <class T>
++class AsyncCallback : public IMFAsyncCallback {
++ public:
++  typedef HRESULT (T::*InvokeFn)(IMFAsyncResult* pAsyncResult);
++
++  AsyncCallback(T* pParent, InvokeFn fn)
++      : m_pParent(pParent), m_pInvokeFn(fn) {}
++
++  // IUnknown
++  STDMETHODIMP_(ULONG) AddRef() {
++    // Delegate to parent class.
++    return m_pParent->AddRef();
++  }
++  STDMETHODIMP_(ULONG) Release() {
++    // Delegate to parent class.
++    return m_pParent->Release();
++  }
++  STDMETHODIMP QueryInterface(REFIID iid, void** ppv) {
++    if (!ppv) {
++      return E_POINTER;
++    }
++    if (iid == __uuidof(IUnknown)) {
++      *ppv = static_cast<IUnknown*>(static_cast<IMFAsyncCallback*>(this));
++    } else if (iid == __uuidof(IMFAsyncCallback)) {
++      *ppv = static_cast<IMFAsyncCallback*>(this);
++    } else {
++      *ppv = NULL;
++      return E_NOINTERFACE;
++    }
++    AddRef();
++    return S_OK;
++  }
++
++  // IMFAsyncCallback methods
++  STDMETHODIMP GetParameters(DWORD*, DWORD*) {
++    // Implementation of this method is optional.
++    return E_NOTIMPL;
++  }
++
++  STDMETHODIMP Invoke(IMFAsyncResult* pAsyncResult) {
++    if (m_pParent != nullptr && m_pInvokeFn != nullptr) {
++      return (m_pParent->*m_pInvokeFn)(pAsyncResult);
++    }
++    return E_POINTER;
++  }
++
++  T* m_pParent;
++  InvokeFn m_pInvokeFn;
++};
++
++#endif  // MODULES_VIDEO_CODING_CODECS_H264_WIN_UTILS_ASYNC_H_
+diff --git a/modules/video_coding/codecs/h264/win/utils/crit_sec.h b/modules/video_coding/codecs/h264/win/utils/crit_sec.h
+new file mode 100644
+index 0000000000..3208061739
+--- /dev/null
++++ b/modules/video_coding/codecs/h264/win/utils/crit_sec.h
+@@ -0,0 +1,57 @@
++/*
++ *  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
++ *
++ *  Use of this source code is governed by a BSD-style license
++ *  that can be found in the LICENSE file in the root of the source
++ *  tree. An additional intellectual property rights grant can be found
++ *  in the file PATENTS.  All contributing project authors may
++ *  be found in the AUTHORS file in the root of the source tree.
++ */
++
++#ifndef MODULES_VIDEO_CODING_CODECS_H264_WIN_UTILS_CRITSEC_H_
++#define MODULES_VIDEO_CODING_CODECS_H264_WIN_UTILS_CRITSEC_H_
++
++#include <WinBase.h>
++
++class CritSec {
++ public:
++  CRITICAL_SECTION m_criticalSection;
++
++ public:
++  CritSec() { InitializeCriticalSectionEx(&m_criticalSection, 100, 0); }
++
++  ~CritSec() { DeleteCriticalSection(&m_criticalSection); }
++
++  _Acquires_lock_(m_criticalSection) void Lock() {
++    EnterCriticalSection(&m_criticalSection);
++  }
++
++  _Releases_lock_(m_criticalSection) void Unlock() {
++    LeaveCriticalSection(&m_criticalSection);
++  }
++};
++
++//////////////////////////////////////////////////////////////////////////
++//  AutoLock
++//  Description: Provides automatic locking and unlocking of a
++//               of a critical section.
++//
++//  Note: The AutoLock object must go out of scope before the CritSec.
++//////////////////////////////////////////////////////////////////////////
++
++class AutoLock {
++ private:
++  CritSec* m_pCriticalSection;
++
++ public:
++  _Acquires_lock_(m_pCriticalSection) explicit AutoLock(CritSec& crit) {
++    m_pCriticalSection = &crit;
++    m_pCriticalSection->Lock();
++  }
++
++  _Releases_lock_(m_pCriticalSection) ~AutoLock() {
++    m_pCriticalSection->Unlock();
++  }
++};
++
++#endif  // MODULES_VIDEO_CODING_CODECS_H264_WIN_UTILS_CRITSEC_H_
+diff --git a/modules/video_coding/codecs/h264/win/utils/sample_attribute_queue.h b/modules/video_coding/codecs/h264/win/utils/sample_attribute_queue.h
+new file mode 100644
+index 0000000000..ece818ee04
+--- /dev/null
++++ b/modules/video_coding/codecs/h264/win/utils/sample_attribute_queue.h
+@@ -0,0 +1,69 @@
++/*
++ *  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
++ *
++ *  Use of this source code is governed by a BSD-style license
++ *  that can be found in the LICENSE file in the root of the source
++ *  tree. An additional intellectual property rights grant can be found
++ *  in the file PATENTS.  All contributing project authors may
++ *  be found in the AUTHORS file in the root of the source tree.
++ */
++
++#ifndef MODULES_VIDEO_CODING_CODECS_H264_WIN_UTILS_SAMPLEATTRIBUTEQUEUE_H_
++#define MODULES_VIDEO_CODING_CODECS_H264_WIN_UTILS_SAMPLEATTRIBUTEQUEUE_H_
++
++#include <stdint.h>
++#include <memory>
++#include <queue>
++#include <utility>
++#include "rtc_base/critical_section.h"
++
++// A sorted queue with certain properties which makes it
++// good for mapping attributes to frames and samples.
++// The ids have to be in increasing order.
++template <typename T>
++class SampleAttributeQueue {
++ public:
++  SampleAttributeQueue() {}
++  ~SampleAttributeQueue() {}
++
++  void push(uint64_t id, const T& t) {
++    rtc::CritScope lock(&_crit);
++    _attributes.push(std::make_pair(id, t));
++  }
++
++  bool pop(uint64_t id, T& outT) {
++    rtc::CritScope lock(&_crit);
++    while (!_attributes.empty()) {
++      auto entry = _attributes.front();
++      if (entry.first > id) {
++        outT = entry.second;
++        return true;
++      } else if (entry.first == id) {
++        outT = entry.second;
++        _attributes.pop();
++        return true;
++      } else {
++        _attributes.pop();
++      }
++    }
++    return false;
++  }
++
++  void clear() {
++    rtc::CritScope lock(&_crit);
++    while (!_attributes.empty()) {
++      _attributes.pop();
++    }
++  }
++
++  uint32_t size() {
++    rtc::CritScope lock(&_crit);
++    return static_cast<uint32_t>(_attributes.size());
++  }
++
++ private:
++  rtc::CriticalSection _crit;
++  std::queue<std::pair<uint64_t, const T>> _attributes;
++};
++
++#endif  // MODULES_VIDEO_CODING_CODECS_H264_WIN_UTILS_SAMPLEATTRIBUTEQUEUE_H_
+diff --git a/modules/video_coding/codecs/h264/win/utils/utils.h b/modules/video_coding/codecs/h264/win/utils/utils.h
+new file mode 100644
+index 0000000000..6928257df4
+--- /dev/null
++++ b/modules/video_coding/codecs/h264/win/utils/utils.h
+@@ -0,0 +1,33 @@
++/*
++ *  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
++ *
++ *  Use of this source code is governed by a BSD-style license
++ *  that can be found in the LICENSE file in the root of the source
++ *  tree. An additional intellectual property rights grant can be found
++ *  in the file PATENTS.  All contributing project authors may
++ *  be found in the AUTHORS file in the root of the source tree.
++ */
++
++#ifndef MODULES_VIDEO_CODING_CODECS_H264_WIN_UTILS_UTILS_H_
++#define MODULES_VIDEO_CODING_CODECS_H264_WIN_UTILS_UTILS_H_
++
++#ifdef _DEBUG
++#define ON_SUCCEEDED(act)                      \
++  if (SUCCEEDED(hr)) {                         \
++    hr = (act);                                \
++    if (FAILED(hr)) {                          \
++      RTC_LOG(LS_WARNING) << "ERROR:" << #act; \
++      __debugbreak();                          \
++    }                                          \
++  }
++#else
++#define ON_SUCCEEDED(act)                      \
++  if (SUCCEEDED(hr)) {                         \
++    hr = (act);                                \
++    if (FAILED(hr)) {                          \
++      RTC_LOG(LS_WARNING) << "ERROR:" << #act; \
++    }                                          \
++  }
++#endif
++
++#endif  // MODULES_VIDEO_CODING_CODECS_H264_WIN_UTILS_UTILS_H_
+diff --git a/webrtc.gni b/webrtc.gni
+index df293432b6..7dc04428c5 100644
+--- a/webrtc.gni
++++ b/webrtc.gni
+@@ -199,6 +199,10 @@ declare_args() {
+   #        Windows 10. It is ok to use this option with any API family
+   #        (desktop (Win32), app (Store), ...).
+   rtc_win_video_capture_winrt = false
++
++  # When is set to true, a H264 encoder using Windows Media Foundation
++  # will be included in libwebrtc.{a|lib}
++  rtc_win_use_mf_h264 = false
+ }
+ 
+ if (!build_with_mozilla) {
+-- 
+2.24.1.windows.2
+

--- a/patches_for_WebRTC_org/m80/patchWebRTCM80.cmd
+++ b/patches_for_WebRTC_org/m80/patchWebRTCM80.cmd
@@ -35,6 +35,7 @@ git.exe am "%PATCH_DIR%0007-Fixing-UWP-build-for-modules-video_capture.patch"
 git.exe am "%PATCH_DIR%0007.1-BUG-Requested-camera-settings-were-not-being-honored.patch"
 git.exe am "%PATCH_DIR%0007.2-Properly-handling-async-model-for-initializing-Media.patch"
 git.exe am "%PATCH_DIR%0007.4-Adding-video-profiles-capabilities-to-the-video-capt.patch"
+git.exe am "%PATCH_DIR%0007.5-Porting-H264-encoder-from-the-WebRTC-UWP-project.patch"
 git.exe am "%PATCH_DIR%0008-Fixing-UWP-build-for-modules-audio_device.patch"
 git.exe am "%PATCH_DIR%6401-Shift-operator-in-Arm-doesn-t-work-the-same-as-Intel.patch"
 popd


### PR DESCRIPTION
    This change ports the H264 encoder from the WebRTC-UWP project. The following are a list of changes made while porting the code:
    . Manually resetting the sink writer to stop generating key frames. Previously, the ::Encode method was adding an attribute to the sink writer for generating a key frame. The flag for generating key frames was not being restored to stop generating key frames. Documentation states that CODECAPI_AVEncVideoForceKeyFrame should reset to zero after the next frame, but visual results are apparently better after manually resetting to zero. This change is experimental and might be reverted in the future.
    . All ComPtrs explicitly call ReleaseAndGetAddressOf instead of operator& to clarify intent.
    . Files renamed to follow WebRTC naming convention.
    . Factory has been updated to use WebRTC's new interface.
    . Encoder's unused data members have been removed.
    . Linker is not instructed to add MF libraries via pragma comment any longer.
    . Adding a build flag for enabling the MF based H264 encoder.