### PR TITLE
Adding missing patch files for m84

### DIFF
--- a/patches_for_WebRTC_org/m84/3006-Disabling-switch-without-case-warning-for-aec3.patch
+++ b/patches_for_WebRTC_org/m84/3006-Disabling-switch-without-case-warning-for-aec3.patch
@@ -1,0 +1,33 @@
+From 84a39ed832e749d7a7161dc9a976e5d67c47bfd8 Mon Sep 17 00:00:00 2001
+From: Augusto Righetto <aurighet@microsoft.com>
+Date: Thu, 2 Jul 2020 15:06:44 -0700
+Subject: [PATCH] Disabling switch without case warning for aec3
+
+---
+ modules/audio_processing/aec3/fft_data.h | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/modules/audio_processing/aec3/fft_data.h b/modules/audio_processing/aec3/fft_data.h
+index 5e5adb62de..7707249704 100644
+--- a/modules/audio_processing/aec3/fft_data.h
++++ b/modules/audio_processing/aec3/fft_data.h
+@@ -44,6 +44,8 @@ struct FftData {
+   void Spectrum(Aec3Optimization optimization,
+                 rtc::ArrayView<float> power_spectrum) const {
+     RTC_DCHECK_EQ(kFftLengthBy2Plus1, power_spectrum.size());
++#pragma warning(push)
++#pragma warning(disable:4065)
+     switch (optimization) {
+ #if defined(WEBRTC_ARCH_X86_FAMILY)
+       case Aec3Optimization::kSse2: {
+@@ -65,6 +67,7 @@ struct FftData {
+         std::transform(re.begin(), re.end(), im.begin(), power_spectrum.begin(),
+                        [](float a, float b) { return a * a + b * b; });
+     }
++#pragma warning(pop)
+   }
+ 
+   // Copy the data from an interleaved array.
+-- 
+2.24.1.windows.2
+

--- a/patches_for_WebRTC_org/m84/4001-Arm64-is-a-thing-and-has-intrinsic-to-mul-two-64bit-.patch
+++ b/patches_for_WebRTC_org/m84/4001-Arm64-is-a-thing-and-has-intrinsic-to-mul-two-64bit-.patch
@@ -1,0 +1,44 @@
+From 19985a00f53fb5368c74d01f1dae5a9d67c8a4ae Mon Sep 17 00:00:00 2001
+From: Augusto Righetto <aurighet@microsoft.com>
+Date: Wed, 25 Mar 2020 23:26:53 -0700
+Subject: [PATCH] Arm64 is a thing and has intrinsic to mul two 64bit uint
+
+---
+ crypto/fipsmodule/bn/internal.h | 6 +++++-
+ include/openssl/base.h          | 2 +-
+ 2 files changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/crypto/fipsmodule/bn/internal.h b/crypto/fipsmodule/bn/internal.h
+index d58a2acce..7b4fba775 100644
+--- a/crypto/fipsmodule/bn/internal.h
++++ b/crypto/fipsmodule/bn/internal.h
+@@ -404,8 +404,12 @@ uint64_t bn_mont_n0(const BIGNUM *n);
+ int bn_mod_exp_base_2_consttime(BIGNUM *r, unsigned p, const BIGNUM *n,
+                                 BN_CTX *ctx);
+ 
+-#if defined(OPENSSL_X86_64) && defined(_MSC_VER)
++#if defined(_MSC_VER)
++#if defined(OPENSSL_X86_64)
+ #define BN_UMULT_LOHI(low, high, a, b) ((low) = _umul128((a), (b), &(high)))
++#elif defined(OPENSSL_AARCH64)
++#define BN_UMULT_LOHI(low, high, a, b) ((low) = (a) * (b), high = __umulh((a), (b)))
++#endif
+ #endif
+ 
+ #if !defined(BN_ULLONG) && !defined(BN_UMULT_LOHI)
+diff --git a/include/openssl/base.h b/include/openssl/base.h
+index e347c09ae..0265c5103 100644
+--- a/include/openssl/base.h
++++ b/include/openssl/base.h
+@@ -90,7 +90,7 @@ extern "C" {
+ #elif defined(__x86) || defined(__i386) || defined(__i386__) || defined(_M_IX86)
+ #define OPENSSL_32_BIT
+ #define OPENSSL_X86
+-#elif defined(__aarch64__)
++#elif defined(__aarch64__) || defined(_M_ARM64)
+ #define OPENSSL_64_BIT
+ #define OPENSSL_AARCH64
+ #elif defined(__arm) || defined(__arm__) || defined(_M_ARM)
+-- 
+2.17.1.windows.2
+

--- a/patches_for_WebRTC_org/m84/5001-Disabling-SIMD-for-ARM64.patch
+++ b/patches_for_WebRTC_org/m84/5001-Disabling-SIMD-for-ARM64.patch
@@ -1,0 +1,25 @@
+From 8bd5b67f681a0ca9060e399429595e17af8399a6 Mon Sep 17 00:00:00 2001
+From: Augusto Righetto <aurighet@microsoft.com>
+Date: Thu, 2 Jul 2020 16:10:33 -0700
+Subject: [PATCH] Disabling SIMD for ARM64
+
+---
+ BUILD.gn | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/BUILD.gn b/BUILD.gn
+index 7e7f6ba..272cc38 100644
+--- a/BUILD.gn
++++ b/BUILD.gn
+@@ -161,7 +161,7 @@ static_library("simd") {
+     ]
+     configs -= [ "//build/config/compiler:default_optimization" ]
+     configs += [ "//build/config/compiler:optimize_speed" ]
+-  } else if (current_cpu == "arm64") {
++  } else if ((current_cpu == "arm64") && (current_os != "winuwp")) {
+     sources = [
+       "simd/arm/arm64/jsimd.c",
+       "simd/arm/arm64/jsimd_neon.S",
+-- 
+2.24.1.windows.2
+

--- a/patches_for_WebRTC_org/m84/patchWebRTCM84.cmd
+++ b/patches_for_WebRTC_org/m84/patchWebRTCM84.cmd
@@ -19,6 +19,14 @@ git.exe am "%PATCH_DIR%2001-Fixing-NV12-to-I420-conversion-with-strides-and-gap.
 if errorlevel 1 goto :error
 popd
 
+pushd %WEBRTCM84_ROOT%\third_party\boringssl\src
+git.exe am "%PATCH_DIR%4001-Arm64-is-a-thing-and-has-intrinsic-to-mul-two-64bit-.patch"
+if errorlevel 1 goto :error
+
+pushd %WEBRTCM84_ROOT%\third_party\libjpeg_turbo
+git.exe am "%PATCH_DIR%5001-Disabling-SIMD-for-ARM64.patch"
+if errorlevel 1 goto :error
+
 pushd %WEBRTCM84_ROOT%
 git.exe am "%PATCH_DIR%3001-Removing-unused-files-containing-Win32-APIs-from-rtc.patch"
 if errorlevel 1 goto :error
@@ -29,6 +37,8 @@ if errorlevel 1 goto :error
 git.exe am "%PATCH_DIR%3004-Changes-for-enabling-the-new-video-capture-module.patch"
 if errorlevel 1 goto :error
 git.exe am "%PATCH_DIR%3005-Adds-the-Media-Foundation-H264-encoder-and-decoder.patch"
+if errorlevel 1 goto :error
+git.exe am "%PATCH_DIR%3006-Disabling-switch-without-case-warning-for-aec3.patch"
 if errorlevel 1 goto :error
 xcopy /Y /E /Q "%PATCH_DIR%\src" .
 if errorlevel 1 goto :error


### PR DESCRIPTION
Some patch files were missing in the previous commit due an inconsistent state of the build artifacts in my machine.
This change adds the m80's patch files for fixing boringssl and aec3.
Unfortunately the SIMD optimizations for libjpeg-turbo had to be temporarily disable. Issue #46 has been filed to follow up on that.

An entire WebRTC repo has been cloned from scratch, a test app has been successfully deployed and executed on an ARM64 device to validate this change.

resolves #44 