### PR TITLE
User/load library/better sync msgs

### DIFF
--- a/patches_for_WebRTC_org/m84/src/modules/video_capture/windows/video_capture_winrt.cc
+++ b/patches_for_WebRTC_org/m84/src/modules/video_capture/windows/video_capture_winrt.cc
@@ -404,7 +404,7 @@ HRESULT VideoCaptureWinRTInternal::StopCapture() {
     }
 
     if (SUCCEEDED(hr)) {
-      hr = WaitForAsyncAction(async_action.Get());
+      hr = WaitForAsyncAction(async_action.Get(), 250);
     }
   }
 


### PR DESCRIPTION
It is possible to have an async operation to complete before the code have opportunity to define the callback for put_Completed. In that situations, the waitable event timesout. 

This change checks if the async operation successfully completed after timingout and not fail the synchronization. Additionally, this change decreases the timeout for stop capturing frames to 250ms.

fixes #59 