### PR TITLE
Added 24000 to the tested sample rates

### DIFF
--- a/patches_for_WebRTC_org/m84/src/modules/audio_device/win/audio_device_core_win.cc
+++ b/patches_for_WebRTC_org/m84/src/modules/audio_device/win/audio_device_core_win.cc
@@ -1142,7 +1142,7 @@ struct CaptureDeviceInternal
     Wfx.Samples.wValidBitsPerSample = Wfx.Format.wBitsPerSample;
     Wfx.SubFormat = KSDATAFORMAT_SUBTYPE_PCM;
 
-    const int freqs[6] = {48000, 44100, 16000, 96000, 32000, 8000};
+    const int freqs[7] = {48000, 44100, 16000, 96000, 32000, 24000, 8000};
     hr = S_FALSE;
 
     // Iterate over frequencies and channels, in order of priority
@@ -1611,7 +1611,7 @@ struct RenderDeviceInternal
     Wfx.wBitsPerSample = 16;
     Wfx.cbSize = 0;
 
-    const int freqs[] = {48000, 44100, 16000, 96000, 32000, 8000};
+    const int freqs[7] = {48000, 44100, 16000, 96000, 32000, 24000, 8000};
     hr = S_FALSE;
 
     // Iterate over frequencies and channels, in order of priority


### PR DESCRIPTION
This is meant to fix a issue that prevents the library from recording audio on Xbox consoles.
The only supported sample rate there is `24000`, that isn't part of the fallback list.