### PR TITLE
Reinitialize mixer after StopTransport

### DIFF
--- a/patches_for_WebRTC_org/m84/src/modules/audio_device/win/audio_device_core_win.cc
+++ b/patches_for_WebRTC_org/m84/src/modules/audio_device/win/audio_device_core_win.cc
@@ -635,6 +635,8 @@ struct AudioDeviceHelper : public DeviceHelper<DEVICE_CLASS> {
       CloseHandle(_hThread);
       _hThread = nullptr;
       _transporting = false;
+      _transportInitialized = false;
+      _mixerInitialized = false;
       return -1;
     }
 
@@ -647,6 +649,8 @@ struct AudioDeviceHelper : public DeviceHelper<DEVICE_CLASS> {
     ResetEvent(_hShutdownEvent);
 
     _transporting = false;
+    _transportInitialized = false;
+    _mixerInitialized = false;
 
     CloseHandle(_hThread);
     _hThread = nullptr;


### PR DESCRIPTION
Current implementation doesn't allow to change render/capture device after the transport has been initialized.
This PR aims to fix the issue.
I've been looking around for additional stuff to be disposed/released, but I couldn't find any.
A possible improvement to this code would be to move this code to `SetDevice` method, and only `if (!Transporting())`.
This way, Stopping and Starting the transport without changing device won't cause a useless reinitialization.

Since in my code base we only stop/start the transports when switching devices, I consider this fine or me.